### PR TITLE
Add centralized config

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,47 +86,18 @@ x = x.drop(index=na_idx).reset_index(drop=True)
   <hr>
   
   <h2>파일 및 코드 수정 안내 🛠</h2>
-  <p><strong>*데이터에 따라 수정하여 사용하는 파이썬 파일과 수정하는 부분*</strong></p>
-  
+  <p>이전 버전에서는 여러 스크립트의 경로와 모델 설정을 각각 수정해야 했습니다. 이제 <code>config.py</code> 하나에서 모든 설정을 관리합니다.</p>
+
   <h3>1. 훈련시</h3>
   <ul>
-    <li>
-      <strong>smiles2fing.py</strong>
-      <ul>
-        <li><code>input_excel_path = "./data/example_data_DBPs/for_train/example_DBPs_ER.xlsx"</code></li>
-        <li><code>output_dir = "./data/example_data_DBPs/for_train/fingerprints"</code></li>
-      </ul>
-    </li>
-    <li>
-      <strong>ToxCast_model_training.sh</strong>
-      <ul>
-        <li><code>models=('dt')</code> (예시: 'xgb', 'gbt', 'rf', 'logistic' 등으로 모델 정의)</li>
-        <li><code>fingerprints=('MACCS')</code> (예시: 'Morgan', 'RDKit', 'Layered', 'Pattern' 등으로 지문 정의)</li>
-        <li><code>file_path = "./data/example_data_DBPs/for_train/example_DBPs_ER.xlsx"</code> (데이터 경로)</li>
-        <li><code>fp_path = "./data/example_data_DBPs/for_train/fingerprint_outputs"</code> (fingerprints 경로)</li>
-        <li><code>data_name = "example_DBPs_ER"</code></li>
-      </ul>
-    </li>
+    <li>SMILES를 분자지문으로 변환할 입력 파일 경로와 출력 디렉토리</li>
+    <li>사용할 모델과 지문 종류</li>
+    <li>훈련 데이터 경로 등은 모두 <code>config.py</code>에 정의됩니다.</li>
   </ul>
-  
+
   <h3>2. 예측시</h3>
   <ul>
-    <li>
-      <strong>smiles2fing.py</strong>
-      <ul>
-        <li><code>input_excel_path = "./data/example_data_DBPs/for_train/example_DBPs_ER.xlsx"</code></li>
-        <li><code>output_dir = "./data/example_data_DBPs/for_train/fingerprints"</code></li>
-      </ul>
-    </li>
-    <li>
-      <strong>Predict_data.py</strong>
-      <ul>
-        <li><code>input_excel_path = "./prediction/example_prediction_DBPs/example_assay_list_ER.xlsx"</code> (수정 필요)</li>
-        <li><code>model_path_base = "./results/example_DBPs_ER/2025-03-25/model_save_path"</code></li>
-        <li><code>input_fp_path_base = "./data/example_data_DBPs/for_predict/fingerprints"</code></li>
-        <li><code>SMILES_path = "./data/example_data_DBPs/for_predict/example_DBPs_for_pred.xlsx"</code></li>
-      </ul>
-    </li>
+    <li>예측에 사용할 모델 경로, 분자지문 파일, SMILES 파일 역시 <code>config.py</code>에서 수정합니다.</li>
   </ul>
   
 </body>

--- a/ToxCast_model/ToxCast_model_training.sh
+++ b/ToxCast_model/ToxCast_model_training.sh
@@ -1,12 +1,32 @@
 #!/bin/bash
 
 pwd
-# 모델 리스트 정의
-models=('dt') # 'xgb' 'gbt' 'rf' 'logistic') # 모델 정의
-fingerprints=('MACCS') # 'Morgan' 'RDKit' 'Layered' 'Pattern') # 지문 정의
-file_path="./data/example_data_DBPs/for_train/example_DBPs_ER.xlsx" # 데이터 경로
-fp_path="./data/example_data_DBPs/for_train/fingerprint_outputs" # fingerprints 경로
-data_name="example_DBPs_ER"
+# config.py에서 변수 읽기
+models=($(python - <<'EOF'
+import config
+print(' '.join(config.MODELS))
+EOF
+))
+fingerprints=($(python - <<'EOF'
+import config
+print(' '.join(config.FINGERPRINTS))
+EOF
+))
+file_path=$(python - <<'EOF'
+import config
+print(config.TRAIN_FILE_PATH)
+EOF
+)
+fp_path=$(python - <<'EOF'
+import config
+print(config.TRAIN_FP_PATH)
+EOF
+)
+data_name=$(python - <<'EOF'
+import config
+print(config.DATA_NAME)
+EOF
+)
 
 current_date=$(date +%Y-%m-%d)
 

--- a/ToxCast_model/config.py
+++ b/ToxCast_model/config.py
@@ -1,0 +1,29 @@
+# Configuration file for training and prediction
+
+# ----- Fingerprint generation -----
+# Source Excel file containing SMILES for fingerprint generation
+SMILES_INPUT_PATH = "./data/example_data_DBPs/for_train/example_DBPs_ER.xlsx"
+# Directory where fingerprint CSV files will be written
+FINGERPRINT_OUTPUT_DIR = "./data/example_data_DBPs/for_train/fingerprints"
+
+# ----- Training -----
+# Models to train
+MODELS = ['dt']  # e.g. ['xgb', 'gbt', 'rf', 'logistic']
+# Fingerprint types used for training
+FINGERPRINTS = ['MACCS']  # e.g. ['Morgan', 'RDKit', 'Layered', 'Pattern']
+# Training Excel file path
+TRAIN_FILE_PATH = "./data/example_data_DBPs/for_train/example_DBPs_ER.xlsx"
+# Directory containing fingerprint CSVs for training
+TRAIN_FP_PATH = "./data/example_data_DBPs/for_train/fingerprint_outputs"
+# Name used for saving results
+DATA_NAME = "example_DBPs_ER"
+
+# ----- Prediction -----
+# Excel file specifying models to load for prediction
+PREDICT_LIST_PATH = "./prediction/example_prediction_DBPs/example_assay_list_ER.xlsx"
+# Base directory where trained models are stored
+MODEL_PATH_BASE = "./results/example_DBPs_ER/2025-03-25/model_save_path"
+# Directory containing fingerprint CSVs for chemicals to predict
+PREDICT_FP_PATH = "./data/example_data_DBPs/for_predict/fingerprints"
+# Excel file with SMILES for the chemicals to predict
+PREDICT_SMILES_PATH = "./data/example_data_DBPs/for_predict/example_DBPs_for_pred.xlsx"

--- a/ToxCast_model/prediction/Predict_data.py
+++ b/ToxCast_model/prediction/Predict_data.py
@@ -3,11 +3,21 @@ import joblib
 import os
 
 if __name__ == "__main__":
-    # 입력 엑셀 파일과 시트명
-    input_excel_path = "/home1/won0316/_RESEARCH/0817_Genotoxicity/1_Git_upload/ChemBAI_ToxCast/ToxCast_model/prediction/250513/250513_prediction_ToxCast.xlsx" #수정
-    model_path_base = "/home1/won0316/_RESEARCH/0817_Genotoxicity/1_Git_upload/ChemBAI_ToxCast/Final_model_save/ToxCast_v.4.2_model_total"
-    input_fp_path_base = "/home1/won0316/_RESEARCH/0817_Genotoxicity/1_Git_upload/ChemBAI_ToxCast/ToxCast_model/data/250513/fingerprints"
-    SMILES_path = "/home1/won0316/_RESEARCH/0817_Genotoxicity/1_Git_upload/ChemBAI_ToxCast/ToxCast_model/prediction/250513/prediction.xlsx"
+    # config.py에 정의된 경로 사용
+    try:
+        from config import (
+            PREDICT_LIST_PATH,
+            MODEL_PATH_BASE,
+            PREDICT_FP_PATH,
+            PREDICT_SMILES_PATH,
+        )
+    except ImportError:
+        raise ImportError("config.py 파일을 찾을 수 없습니다. 'ToxCast_model' 디렉토리에서 실행해 주세요.")
+
+    input_excel_path = PREDICT_LIST_PATH
+    model_path_base = MODEL_PATH_BASE
+    input_fp_path_base = PREDICT_FP_PATH
+    SMILES_path = PREDICT_SMILES_PATH
 
     # 입력 데이터 읽기
     data = pd.read_excel(input_excel_path)

--- a/ToxCast_model/toxcast_pkg/smiles2fing.py
+++ b/ToxCast_model/toxcast_pkg/smiles2fing.py
@@ -44,9 +44,14 @@ def Smiles2Fing(smiles, fingerprint_type='MACCS'):
 
 
 if __name__ == "__main__":
-    # 입력 파일 경로 설정
-    input_excel_path = "/home1/won0316/_RESEARCH/0817_Genotoxicity/1_Git_upload/ChemBAI_ToxCast/ToxCast_model/prediction/250513/prediction.xlsx"  # 입력 엑셀 파일 경로 : 훈련 or 예측에 사용할 데이터
-    output_dir = "/home1/won0316/_RESEARCH/0817_Genotoxicity/1_Git_upload/ChemBAI_ToxCast/ToxCast_model/data/250513/fingerprints"  # DBPs/for_predict/example_DBPs 디렉토리
+    # config.py에 정의된 경로 사용
+    try:
+        from config import SMILES_INPUT_PATH, FINGERPRINT_OUTPUT_DIR
+    except ImportError:
+        raise ImportError("config.py 파일을 찾을 수 없습니다. 'ToxCast_model' 디렉토리에서 실행해 주세요.")
+
+    input_excel_path = SMILES_INPUT_PATH  # 입력 엑셀 파일 경로 : 훈련 or 예측에 사용할 데이터
+    output_dir = FINGERPRINT_OUTPUT_DIR  # fingerprints를 저장할 디렉토리
 
     # 출력 디렉토리 생성
     os.makedirs(output_dir, exist_ok=True)

--- a/ToxCast_model/v.2/toxcast_pkg/smiles2fing.py
+++ b/ToxCast_model/v.2/toxcast_pkg/smiles2fing.py
@@ -44,9 +44,14 @@ def Smiles2Fing(smiles, fingerprint_type='MACCS'):
 
 
 if __name__ == "__main__":
-    # 입력 파일 경로 설정
-    input_excel_path = "./data/example_data_DBPs/for_train/example_DBPs_ER.xlsx"  # 입력 엑셀 파일 경로 : 훈련 or 예측에 사용할 데이터
-    output_dir = "./data/example_data_DBPs/for_train/fingerprints"  # DBPs/for_predict/example_DBPs 디렉토리
+    # config.py에 정의된 경로 사용
+    try:
+        from config import SMILES_INPUT_PATH, FINGERPRINT_OUTPUT_DIR
+    except ImportError:
+        raise ImportError("config.py 파일을 찾을 수 없습니다. 'ToxCast_model' 디렉토리에서 실행해 주세요.")
+
+    input_excel_path = SMILES_INPUT_PATH  # 입력 엑셀 파일 경로 : 훈련 or 예측에 사용할 데이터
+    output_dir = FINGERPRINT_OUTPUT_DIR  # fingerprints를 저장할 디렉토리
 
     # 출력 디렉토리 생성
     os.makedirs(output_dir, exist_ok=True)


### PR DESCRIPTION
## Summary
- add `config.py` with paths and options
- refactor `smiles2fing.py`, training script and prediction script to read from `config.py`
- update README to mention single config

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d044694a8832087c3b2b883a11343