### PR TITLE
Fix path handling for prediction scripts

### DIFF
--- a/ToxCast_model/run_pipeline.sh
+++ b/ToxCast_model/run_pipeline.sh
@@ -5,7 +5,7 @@
 cd "$(dirname "$0")"
 
 # generate fingerprints
-python -m ./toxcast_pkg.smiles2fing
+python -m toxcast_pkg.smiles2fing
 
 # determine mode
 mode=$(python - <<'PY'
@@ -19,7 +19,7 @@ echo "Running mode: $mode"
 if [ "$mode" = "training" ]; then
     bash ./ToxCast_model_training.sh
 elif [ "$mode" = "prediction" ]; then
-    python ./prediction/Predict_data.py
+    PYTHONPATH="$(pwd)" python ./prediction/Predict_data.py
 else
     echo "Unknown mode: $mode"
     exit 1


### PR DESCRIPTION
## Summary
- call fingerprints module correctly in `run_pipeline.sh`
- set PYTHONPATH when calling `Predict_data.py` so that `config.py` resolves properly

## Testing
- `bash ToxCast_model/run_pipeline.sh | head -n 20` *(fails: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685df13a7e3c832087bb9ccc246221fc