### PR TITLE
Implement automatic dataset file detection

### DIFF
--- a/ToxCast_model/ToxCast_model_training.sh
+++ b/ToxCast_model/ToxCast_model_training.sh
@@ -13,8 +13,12 @@ print(' '.join(config.FINGERPRINTS))
 EOF
 ))
 file_path=$(python - <<'EOF'
-import config
-print(config.TRAIN_FILE_PATH)
+import config, os
+from toxcast_pkg.common import find_single_excel_file
+p = config.TRAIN_FILE_PATH
+if os.path.isdir(p):
+    p = find_single_excel_file(p)
+print(p)
 EOF
 )
 fp_path=$(python - <<'EOF'

--- a/ToxCast_model/prediction/Predict_data.py
+++ b/ToxCast_model/prediction/Predict_data.py
@@ -18,6 +18,9 @@ if __name__ == "__main__":
     model_path_base = MODEL_PATH_BASE
     input_fp_path_base = PREDICT_FP_PATH
     SMILES_path = PREDICT_SMILES_PATH
+    if os.path.isdir(SMILES_path):
+        from toxcast_pkg.common import find_single_excel_file
+        SMILES_path = find_single_excel_file(SMILES_path)
 
     # 입력 데이터 읽기
     data = pd.read_excel(input_excel_path)

--- a/ToxCast_model/toxcast_pkg/common.py
+++ b/ToxCast_model/toxcast_pkg/common.py
@@ -116,3 +116,15 @@ def CV(x, y, model, params, seed):
                                   np.mean(val_accuracy_)]))
     
     return(result)
+
+
+def find_single_excel_file(base_dir):
+    """Return the single Excel file directly inside base_dir.
+    If multiple or none exist, raise an error."""
+    import os
+    files = [f for f in os.listdir(base_dir) if f.lower().endswith((".xlsx", ".xls"))]
+    if len(files) == 0:
+        raise FileNotFoundError(f"{base_dir} 디렉토리에 엑셀 파일이 없습니다.")
+    if len(files) > 1:
+        raise RuntimeError(f"{base_dir} 디렉토리에 예측/훈련용 데이터셋을 하나만 남기세요.")
+    return os.path.join(base_dir, files[0])

--- a/ToxCast_model/toxcast_pkg/smiles2fing.py
+++ b/ToxCast_model/toxcast_pkg/smiles2fing.py
@@ -50,7 +50,10 @@ if __name__ == "__main__":
     except ImportError:
         raise ImportError("config.py 파일을 찾을 수 없습니다. 'ToxCast_model' 디렉토리에서 실행해 주세요.")
 
-    input_excel_path = SMILES_INPUT_PATH  # 입력 엑셀 파일 경로 : 훈련 or 예측에 사용할 데이터
+    input_excel_path = SMILES_INPUT_PATH  # 입력 엑셀 파일 경로 또는 디렉토리
+    if os.path.isdir(input_excel_path):
+        from toxcast_pkg.common import find_single_excel_file
+        input_excel_path = find_single_excel_file(input_excel_path)
     output_dir = FINGERPRINT_OUTPUT_DIR  # fingerprints를 저장할 디렉토리
 
     # 출력 디렉토리 생성


### PR DESCRIPTION
## Summary
- add `find_single_excel_file` helper to locate a unique Excel file in a directory
- use this helper when generating fingerprints, running predictions and training

## Testing
- `python -m py_compile ToxCast_model/toxcast_pkg/common.py ToxCast_model/toxcast_pkg/smiles2fing.py ToxCast_model/prediction/Predict_data.py`
- `bash -n ToxCast_model/ToxCast_model_training.sh`

------
https://chatgpt.com/codex/tasks/task_e_685dfe1bd37483208ebb5c535237e714