### PR TITLE
Simplify config and document pipeline usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,5 +104,13 @@ x = x.drop(index=na_idx).reset_index(drop=True)
     <code>config.py</code>에서 <code>OBJECT</code> 값을 0(predict) 또는 1(train)으로
     설정하면 해당 모드로 동작합니다.</p>
 
+  <h2>run_pipeline 사용 방법 📚</h2>
+  <ol>
+    <li>훈련 또는 예측에 필요한 엑셀 파일을 <code>data/</code> 하위에 준비합니다.</li>
+    <li><code>config.py</code>에서 파일 경로와 모델 옵션을 원하는 값으로 수정합니다.</li>
+    <li><code>OBJECT</code> 값을 0이면 예측, 1이면 훈련 모드로 설정합니다.</li>
+    <li>프로젝트 루트에서 <code>bash run_pipeline.sh</code> 명령으로 파이프라인을 실행합니다.</li>
+  </ol>
+
 </body>
 </html>

--- a/ToxCast_model/config.py
+++ b/ToxCast_model/config.py
@@ -1,45 +1,30 @@
 from pathlib import Path
 
-# Configuration file for training and prediction
+"""Centralized configuration for training and prediction."""
 
-
-# ----- Execution mode -----
-# Choose between prediction or training.
-# OBJECTS[0] -> "prediction", OBJECTS[1] -> "training"
+# execution mode: 0 -> prediction, 1 -> training
 OBJECTS = ["prediction", "training"]
-# Set OBJECT to 0 for prediction or 1 for training
 OBJECT = 0
 
+# common directories
 INPUT_ROOT = Path("data")
 OUTPUT_ROOT = Path("results")
 
-
-# ----- Fingerprint generation -----
-# Source Excel file containing SMILES for fingerprint generation
+# fingerprint generation
 SMILES_INPUT_PATH = "./data/example_data_DBPs/for_train/example_DBPs_ER.xlsx"
-# Directory where fingerprint CSV files will be written
 FINGERPRINT_OUTPUT_DIR = "./data/example_data_DBPs/for_train/fingerprints"
 
-# ----- Training -----
-# Models to train
-MODELS = ['dt']  # e.g. ['xgb', 'gbt', 'rf', 'logistic']
-# Fingerprint types used for training
-FINGERPRINTS = ['MACCS']  # e.g. ['Morgan', 'RDKit', 'Layered', 'Pattern']
-# Training Excel file path
+# training settings
+MODELS = ["dt"]
+FINGERPRINTS = ["MACCS"]
 TRAIN_FILE_PATH = "./data/example_data_DBPs/for_train/example_DBPs_ER.xlsx"
-# Directory containing fingerprint CSVs for training
 TRAIN_FP_PATH = "./data/example_data_DBPs/for_train/fingerprint_outputs"
-# Name used for saving results
 DATA_NAME = "example_DBPs_ER"
 
-# ----- Prediction -----
-# Excel file specifying models to load for prediction
+# prediction settings
 PREDICT_LIST_PATH = "./prediction/example_prediction_DBPs/example_assay_list_ER.xlsx"
-# Base directory where trained models are stored
 MODEL_PATH_BASE = "../Final_model_save/ToxCast_v.4.2_model_total"
-# Directory containing fingerprint CSVs for chemicals to predict
 PREDICT_FP_PATH = "./data/example_data_DBPs/for_predict/fingerprints"
-# Excel file with SMILES for the chemicals to predict
 PREDICT_SMILES_PATH = "./data/example_data_DBPs/for_predict/example_DBPs_for_pred.xlsx"
 
 


### PR DESCRIPTION
## Summary
- simplify `config.py` to only keep required settings
- document how to run `run_pipeline.sh` in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685e1d993ec88320954477a02ee73ce8