### PR TITLE
Simplify config paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,5 +104,19 @@ x = x.drop(index=na_idx).reset_index(drop=True)
     <code>config.py</code>에서 <code>OBJECT</code> 값을 0(predict) 또는 1(train)으로
     설정하면 해당 모드로 동작합니다.</p>
 
+  <h2>run_pipeline 사용 방법 📚</h2>
+  <ol>
+    <li>
+      <code>experiments/년월일/PROJECT_NAME/</code> 폴더를 만들고
+      동일한 이름의 엑셀 파일 <code>{PROJECT_NAME}.xlsx</code>을 그 안에 둡니다.
+    </li>
+    <li>
+      <code>config.py</code>에서 <code>PROJECT_NAME</code>과 실행 모드 <code>OBJECT</code>
+      (&nbsp;0: 예측, 1: 훈련&nbsp;)만 수정합니다. 필요하면 <code>EXPERIMENT_DATE</code>
+      를 지정합니다.
+    </li>
+    <li>프로젝트 루트에서 <code>bash run_pipeline.sh</code> 명령으로 파이프라인을 실행합니다.</li>
+  </ol>
+
 </body>
 </html>

--- a/ToxCast_model/ToxCast_model_training.sh
+++ b/ToxCast_model/ToxCast_model_training.sh
@@ -32,6 +32,19 @@ print(config.DATA_NAME)
 EOF
 )
 
+results_dir=$(python - <<'EOF'
+import config
+print(config.RESULTS_DIR)
+EOF
+)
+logs_dir=$(python - <<'EOF'
+import config
+from pathlib import Path
+print((config.BASE_DIR / 'logs').as_posix())
+EOF
+)
+
+# deprecated but kept for compatibility
 current_date=$(date +%Y-%m-%d)
 
 # 동시에 실행할 작업의 최대 수
@@ -45,12 +58,12 @@ for assay_num in {1..3}; do # 반복 범위 변경 가능
     assay_name=$(python -c "import pandas as pd; df = pd.read_excel('${file_path}', header=None); print(df.iloc[0, int('${assay_num}') + 1])")
 
     # 로그 디렉토리 생성
-    mkdir -p "./logs/${data_name}/$current_date/${assay_name}"
+    mkdir -p "${logs_dir}/${assay_name}"
     for model in "${models[@]}"; do
         for fingerprint in "${fingerprints[@]}"; do
             # 결과 저장 디렉토리 생성
-            mkdir -p ./results/${data_name}/$current_date/model_save_path/${assay_name}/${assay_name}_${fingerprint}_${model}
-            model_save_path="./results/${data_name}/$current_date/model_save_path/${assay_name}/${assay_name}_${fingerprint}_${model}"
+            mkdir -p "${results_dir}/model_save_path/${assay_name}/${assay_name}_${fingerprint}_${model}"
+            model_save_path="${results_dir}/model_save_path/${assay_name}/${assay_name}_${fingerprint}_${model}"
 
             echo "[$(date)]   Submitting job for assay_num: $assay_name, model: $model with fingerprint: $fingerprint"
             echo "[$(date)]   Running ${assay_name}/${assay_name}_${fingerprint}_${model}"
@@ -62,8 +75,8 @@ for assay_num in {1..3}; do # 반복 범위 변경 가능
                 --model_save_path ${model_save_path} \
                 --assay_num $((assay_num)) \
                 --fp_path ${fp_path} \
-                > ./logs/${data_name}/$current_date/${assay_name}/${assay_name}_${fingerprint}_${model}.log \
-                2> ./logs/${data_name}/$current_date/${assay_name}/${assay_name}_${fingerprint}_${model}.err &
+                > "${logs_dir}/${assay_name}/${assay_name}_${fingerprint}_${model}.log" \
+                2> "${logs_dir}/${assay_name}/${assay_name}_${fingerprint}_${model}.err" &
 
             # 작업 관리
             ((current_jobs++))

--- a/ToxCast_model/config.py
+++ b/ToxCast_model/config.py
@@ -1,45 +1,39 @@
 from pathlib import Path
+from datetime import datetime
 
-# Configuration file for training and prediction
+"""Centralized configuration for training and prediction."""
 
-
-# ----- Execution mode -----
-# Choose between prediction or training.
-# OBJECTS[0] -> "prediction", OBJECTS[1] -> "training"
+# execution mode: 0 -> prediction, 1 -> training
 OBJECTS = ["prediction", "training"]
-# Set OBJECT to 0 for prediction or 1 for training
 OBJECT = 0
 
-INPUT_ROOT = Path("data")
-OUTPUT_ROOT = Path("results")
+# ----- Basic experiment info -----
+# Only change PROJECT_NAME (and optionally EXPERIMENT_DATE) for each run.
+PROJECT_NAME = "example_project"
+EXPERIMENT_DATE = datetime.now().strftime("%y%m%d")
 
+# ----- Derived paths based on the directory layout -----
+BASE_DIR = Path("experiments") / EXPERIMENT_DATE / PROJECT_NAME
+DATA_FILE = BASE_DIR / f"{PROJECT_NAME}.xlsx"
+FINGERPRINT_DIR = BASE_DIR / "fingerprints"
+RESULTS_DIR = BASE_DIR / "results"
 
-# ----- Fingerprint generation -----
-# Source Excel file containing SMILES for fingerprint generation
-SMILES_INPUT_PATH = "./data/example_data_DBPs/for_train/example_DBPs_ER.xlsx"
-# Directory where fingerprint CSV files will be written
-FINGERPRINT_OUTPUT_DIR = "./data/example_data_DBPs/for_train/fingerprints"
+# fingerprint generation
+SMILES_INPUT_PATH = DATA_FILE
+FINGERPRINT_OUTPUT_DIR = FINGERPRINT_DIR
 
-# ----- Training -----
-# Models to train
-MODELS = ['dt']  # e.g. ['xgb', 'gbt', 'rf', 'logistic']
-# Fingerprint types used for training
-FINGERPRINTS = ['MACCS']  # e.g. ['Morgan', 'RDKit', 'Layered', 'Pattern']
-# Training Excel file path
-TRAIN_FILE_PATH = "./data/example_data_DBPs/for_train/example_DBPs_ER.xlsx"
-# Directory containing fingerprint CSVs for training
-TRAIN_FP_PATH = "./data/example_data_DBPs/for_train/fingerprint_outputs"
-# Name used for saving results
-DATA_NAME = "example_DBPs_ER"
+# training settings
+MODELS = ["dt"]
+FINGERPRINTS = ["MACCS"]
+TRAIN_FILE_PATH = DATA_FILE
+TRAIN_FP_PATH = FINGERPRINT_DIR
+DATA_NAME = PROJECT_NAME
 
-# ----- Prediction -----
-# Excel file specifying models to load for prediction
-PREDICT_LIST_PATH = "./prediction/example_prediction_DBPs/example_assay_list_ER.xlsx"
-# Base directory where trained models are stored
-MODEL_PATH_BASE = "../Final_model_save/ToxCast_v.4.2_model_total"
-# Directory containing fingerprint CSVs for chemicals to predict
-PREDICT_FP_PATH = "./data/example_data_DBPs/for_predict/fingerprints"
-# Excel file with SMILES for the chemicals to predict
-PREDICT_SMILES_PATH = "./data/example_data_DBPs/for_predict/example_DBPs_for_pred.xlsx"
+# prediction settings
+PREDICT_LIST_PATH = BASE_DIR / "assay_list.xlsx"
+MODEL_PATH_BASE = Path("../Final_model_save/ToxCast_v.4.2_model_total")
+PREDICT_FP_PATH = FINGERPRINT_DIR
+PREDICT_SMILES_PATH = DATA_FILE
+
 
 


### PR DESCRIPTION
## Summary
- update `config.py` to auto-build experiment paths from date and project name
- adjust `ToxCast_model_training.sh` to use new path variables
- document directory layout and updated usage instructions

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685e1d993ec88320954477a02ee73ce8