### PR TITLE
Fix config variable, handle prediction path

### DIFF
--- a/ToxCast_model/config.py
+++ b/ToxCast_model/config.py
@@ -20,6 +20,7 @@ PROJECT_NAME = "example"
 BASE_DIR = Path("experiments") / PROJECT_NAME
 
 FINGERPRINT_DIR = BASE_DIR / "fingerprints"
+FINGERPRINT_OUTPUT_DIR = FINGERPRINT_DIR
 RESULTS_DIR = BASE_DIR / "results"
 
 # fingerprint generation

--- a/ToxCast_model/toxcast_pkg/smiles2fing.py
+++ b/ToxCast_model/toxcast_pkg/smiles2fing.py
@@ -46,7 +46,7 @@ def Smiles2Fing(smiles, fingerprint_type='MACCS'):
 if __name__ == "__main__":
     # config.py에 정의된 경로 사용
     try:
-        from config import SMILES_INPUT_PATH, FINGERPRINT_OUTPUT_DIR
+        from config import SMILES_INPUT_PATH, FINGERPRINT_DIR
     except ImportError:
         raise ImportError("config.py 파일을 찾을 수 없습니다. 'ToxCast_model' 디렉토리에서 실행해 주세요.")
 
@@ -54,7 +54,7 @@ if __name__ == "__main__":
     if os.path.isdir(input_excel_path):
         from toxcast_pkg.common import find_single_excel_file
         input_excel_path = find_single_excel_file(input_excel_path)
-    output_dir = FINGERPRINT_OUTPUT_DIR  # fingerprints를 저장할 디렉토리
+    output_dir = FINGERPRINT_DIR  # fingerprints를 저장할 디렉토리
 
     # 출력 디렉토리 생성
     os.makedirs(output_dir, exist_ok=True)

--- a/ToxCast_model/v.2/toxcast_pkg/smiles2fing.py
+++ b/ToxCast_model/v.2/toxcast_pkg/smiles2fing.py
@@ -46,12 +46,12 @@ def Smiles2Fing(smiles, fingerprint_type='MACCS'):
 if __name__ == "__main__":
     # config.py에 정의된 경로 사용
     try:
-        from config import SMILES_INPUT_PATH, FINGERPRINT_OUTPUT_DIR
+        from config import SMILES_INPUT_PATH, FINGERPRINT_DIR
     except ImportError:
         raise ImportError("config.py 파일을 찾을 수 없습니다. 'ToxCast_model' 디렉토리에서 실행해 주세요.")
 
     input_excel_path = SMILES_INPUT_PATH  # 입력 엑셀 파일 경로 : 훈련 or 예측에 사용할 데이터
-    output_dir = FINGERPRINT_OUTPUT_DIR  # fingerprints를 저장할 디렉토리
+    output_dir = FINGERPRINT_DIR  # fingerprints를 저장할 디렉토리
 
     # 출력 디렉토리 생성
     os.makedirs(output_dir, exist_ok=True)

--- a/run_pipeline.sh
+++ b/run_pipeline.sh
@@ -29,7 +29,7 @@ case "$mode" in
         bash ToxCast_model_training.sh
         ;;
     prediction)
-        python prediction/Predict_data.py
+        PYTHONPATH=. python prediction/Predict_data.py
         ;;
     *)
         echo "Unknown mode: $mode"


### PR DESCRIPTION
## Summary
- add `FINGERPRINT_OUTPUT_DIR` in `config.py`
- use `FINGERPRINT_DIR` in fingerprint scripts
- set `PYTHONPATH` when launching `Predict_data.py`

## Testing
- `bash run_pipeline.sh` *(fails: No module named 'sklearn' and 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685e34df4ccc8320b7e7168943cc944d