### PR TITLE
Add F1 model selection option

### DIFF
--- a/ToxCast_model/config.py
+++ b/ToxCast_model/config.py
@@ -41,9 +41,23 @@ DATA_NAME = PROJECT_NAME
 # prediction settings
 
 PREDICT_LIST_PATH = BASE_DIR
-MODEL_PATH_BASE = Path("../Final_model_save/ToxCast_v.4.2_model_total")
+# model selection
+# 0 -> best F1 model (assay_name only)
+# 1 -> user-specified model and fingerprint
+MODEL_SELECTION_OPTIONS = ["best_f1", "model+mf"]
+MODEL_SELECTION = 0
+
+# base directories for each selection mode
+MODEL_PATH_BASE_0 = Path("../Final_model_save/ToxCast_model(F1)")
+MODEL_PATH_BASE_1 = Path("../Final_model_save/ToxCast_v.4.2_model_total")
+
 PREDICT_FP_PATH = FINGERPRINT_DIR
 PREDICT_SMILES_PATH = BASE_DIR
+
+
+def get_model_base():
+    """Return the base directory for prediction models."""
+    return MODEL_PATH_BASE_0 if MODEL_SELECTION == 0 else MODEL_PATH_BASE_1
 
 
 

--- a/ToxCast_model/prediction/Predict_data.py
+++ b/ToxCast_model/prediction/Predict_data.py
@@ -10,7 +10,9 @@ if __name__ == "__main__":
     try:
         from config import (
             PREDICT_LIST_PATH,
-            MODEL_PATH_BASE,
+            MODEL_SELECTION,
+            MODEL_PATH_BASE_0,
+            MODEL_PATH_BASE_1,
             PREDICT_FP_PATH,
             PREDICT_SMILES_PATH,
             RESULTS_DIR,
@@ -19,7 +21,7 @@ if __name__ == "__main__":
         raise ImportError("config.py 파일을 찾을 수 없습니다. 'ToxCast_model' 디렉토리에서 실행해 주세요.")
 
     input_excel_path = PREDICT_LIST_PATH
-    model_path_base = MODEL_PATH_BASE
+    model_path_base = MODEL_PATH_BASE_0 if MODEL_SELECTION == 0 else MODEL_PATH_BASE_1
     input_fp_path_base = PREDICT_FP_PATH
     SMILES_path = PREDICT_SMILES_PATH
     if os.path.isdir(input_excel_path):
@@ -35,7 +37,10 @@ if __name__ == "__main__":
     SMILES = SMILES_df['SMILES']
 
     # 필요한 열 추출
-    required_columns = ["assay_name", "Model", "MF"]
+    if MODEL_SELECTION == 0:
+        required_columns = ["assay_name"]
+    else:
+        required_columns = ["assay_name", "Model", "MF"]
     if not all(col in data.columns for col in required_columns):
         raise KeyError(f"필요한 열 {required_columns}이(가) 엑셀 파일에 없습니다.")
 
@@ -46,12 +51,28 @@ if __name__ == "__main__":
     # 반복문으로 각 모델에 대해 처리
     for _, row in data.iterrows():
         assay_name = row["assay_name"]
-        model_type = row["Model"]
-        mf_type = row["MF"]
-        print(assay_name, model_type, mf_type)
 
-        model_path = f"{model_path_base}/{assay_name}_{mf_type}_{model_type}/{assay_name}_best_model_{mf_type}_{model_type}.joblib"
-
+        if MODEL_SELECTION == 0:
+            # locate model automatically from best F1 directory
+            pattern = f"{model_path_base}/{assay_name}_*/{assay_name}_best_model_*.joblib"
+            matches = list(Path(model_path_base).glob(f"{assay_name}_*/{assay_name}_best_model_*.joblib"))
+            if len(matches) != 1:
+                print(f"모델 파일을 찾지 못했습니다: {pattern}")
+                continue
+            model_path = str(matches[0])
+            filename = os.path.basename(model_path)
+            prefix = f"{assay_name}_best_model_"
+            mf_model = filename[len(prefix):-len(".joblib")]
+            try:
+                mf_type, model_type = mf_model.split("_", 1)
+            except ValueError:
+                print(f"모델 파일 이름에서 MF와 모델 타입을 파싱할 수 없습니다: {filename}")
+                continue
+        else:
+            model_type = row["Model"]
+            mf_type = row["MF"]
+            model_path = f"{model_path_base}/{assay_name}_{mf_type}_{model_type}/{assay_name}_best_model_{mf_type}_{model_type}.joblib"
+        
         if not os.path.exists(model_path):
             print(f"모델 파일이 존재하지 않습니다: {model_path}")
             continue


### PR DESCRIPTION
## Summary
- provide new `MODEL_SELECTION` setting in config.py
- support automatic F1 model loading when `MODEL_SELECTION==0`
- update prediction script to handle both F1 and user-specified models

## Testing
- `python -m py_compile ToxCast_model/prediction/Predict_data.py ToxCast_model/config.py`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685e48afd04083209986910737a26c80