### PR TITLE
Use training fingerprints for DoA

### DIFF
--- a/ToxCast_model/prediction/Predict_data.py
+++ b/ToxCast_model/prediction/Predict_data.py
@@ -67,7 +67,6 @@ if __name__ == "__main__":
     all_results = pd.DataFrame()
     metadata_records = []
     # cache training fingerprints for DoA calculation
-    train_fp_base = Path("data/ToxCast_v.4.1_v.2/fingerprints")
     train_fp_cache = {}
 
     # 반복문으로 각 모델에 대해 처리
@@ -127,21 +126,19 @@ if __name__ == "__main__":
         predictions = model.predict(input_data)
 
         if not skip_doa:
-            # DoA 계산을 위한 학습 fingerprint 로드
-            if mf_type not in train_fp_cache:
-                train_fp_path = train_fp_base / f"{mf_type}.csv"
-                if not train_fp_path.exists():
-                    print(f"학습 fingerprint 파일이 존재하지 않습니다: {train_fp_path}")
-                    train_fp_cache[mf_type] = None
+            # DoA 계산을 위한 학습 fingerprint 로드 (model specific)
+            train_fp_path = Path(model_path).parent / "train_fps.csv"
+            cache_key = str(train_fp_path)
+            if cache_key not in train_fp_cache:
+                if train_fp_path.exists():
+                    train_fp_cache[cache_key] = pd.read_csv(train_fp_path).astype(bool).values
                 else:
-                    train_fp_cache[mf_type] = pd.read_csv(train_fp_path).astype(bool).values
+                    print(f"학습 fingerprint 파일이 존재하지 않습니다: {train_fp_path}")
+                    train_fp_cache[cache_key] = None
 
-            train_fps = train_fp_cache.get(mf_type)
+            train_fps = train_fp_cache.get(cache_key)
             if train_fps is not None:
-                doa_values = [
-                    _tanimoto_max(fp.astype(bool), train_fps)
-                    for fp in input_data.to_numpy()
-                ]
+                doa_values = [_tanimoto_max(fp.astype(bool), train_fps) for fp in input_data.to_numpy()]
             else:
                 doa_values = [None] * len(input_data)
         else:

--- a/ToxCast_model/prediction/calc_doa.py
+++ b/ToxCast_model/prediction/calc_doa.py
@@ -12,6 +12,8 @@ try:
         RESULTS_DIR,
         PREDICT_FP_PATH,
         PREDICT_SMILES_PATH,
+        PREDICT_LIST_PATH,
+        get_model_base,
     )
 except ImportError:
     raise ImportError("Run from within ToxCast_model directory")
@@ -26,23 +28,35 @@ def load_latest_prediction() -> Path:
 
 def main(pred_file: Path) -> None:
     pred_df = pd.read_excel(pred_file)
-    metadata_path = Path(RESULTS_DIR) / 'metadata.json'
-    if not metadata_path.exists():
-        raise FileNotFoundError(f'Metadata not found: {metadata_path}')
-    with open(metadata_path, 'r', encoding='utf-8') as f:
-        meta = json.load(f)
-    assay_to_mf = {m['ASSAY']: m.get('MF') for m in meta if m.get('MF')}
+
+    excel_path = PREDICT_LIST_PATH
+    if Path(excel_path).is_dir():
+        from toxcast_pkg.common import find_single_excel_file
+        excel_path = find_single_excel_file(excel_path)
+    assay_df = pd.read_excel(excel_path, sheet_name='assay_list')
+    required_cols = {'assay_name', 'MF', 'Model'}
+    if not required_cols.issubset(assay_df.columns):
+        missing = required_cols.difference(assay_df.columns)
+        raise KeyError(f"assay_list sheet missing columns: {', '.join(missing)}")
+    assay_info = {
+        row['assay_name']: {'MF': row['MF'], 'model_type': row['Model']}
+        for _, row in assay_df.iterrows()
+    }
 
     smiles_df = pd.read_excel(PREDICT_SMILES_PATH, sheet_name='data')
     drop_cache = {}
-    train_fp_base = Path('data/ToxCast_v.4.1_v.2/fingerprints')
     train_cache = {}
     test_cache = {}
+    model_base = get_model_base()
 
-    for assay, mf in assay_to_mf.items():
-        if mf not in train_cache:
-            train_fp = pd.read_csv(train_fp_base / f'{mf}.csv').astype(bool).values
-            train_cache[mf] = train_fp
+    for assay, info in assay_info.items():
+        mf = info['MF']
+        model_type = info['model_type']
+        if assay not in train_cache:
+            train_fp_path = Path(model_base) / f'{assay}_{mf}_{model_type}' / 'train_fps.csv'
+            if not train_fp_path.exists():
+                raise FileNotFoundError(f'Training fingerprints not found: {train_fp_path}')
+            train_cache[assay] = pd.read_csv(train_fp_path).astype(bool).values
         if mf not in test_cache:
             test_fp = pd.read_csv(Path(PREDICT_FP_PATH) / f'{mf}.csv').astype(bool).values
             drop_idx_path = Path(PREDICT_FP_PATH) / f'{mf}_dropidx.csv'
@@ -54,7 +68,7 @@ def main(pred_file: Path) -> None:
             if drop_idx:
                 test_fp = np.delete(test_fp, drop_idx, axis=0)
             test_cache[mf] = test_fp
-        train_fp = train_cache[mf]
+        train_fp = train_cache[assay]
         test_fp = test_cache[mf]
         doa_vals = [_tanimoto_max(fp.astype(bool), train_fp) for fp in test_fp]
         pred_df[f'{assay}_DoA'] = doa_vals
@@ -66,7 +80,6 @@ def main(pred_file: Path) -> None:
         if 'DTXSID' not in pred_df.columns:
             pred_df.insert(0, 'DTXSID', dtxsid_filtered)
 
-    timestamp = datetime.now().strftime('%Y-%m-%d_%H-%M-%S')
     out_path = pred_file.with_name(pred_file.stem + '_doa.xlsx')
     pred_df.to_excel(out_path, index=False)
     print(f'DoA results saved to {out_path}')

--- a/ToxCast_model/run/dt.py
+++ b/ToxCast_model/run/dt.py
@@ -93,6 +93,10 @@ def main(fingerprint_type, file_path, model_save_path, assay_num, fp_path):
 
     x_train, x_test, y_train, y_test = train_test_split(x, y, test_size=0.2, shuffle=True, random_state=42)
 
+    # Save training fingerprints for DoA calculation
+    train_fp_path = os.path.join(model_save_path, "train_fps.csv")
+    x_train.to_csv(train_fp_path, index=False)
+
     params_dict = {
         'criterion': ['gini', 'entropy'],
         'max_depth': [None, 1, 2, 3, 4, 5],

--- a/ToxCast_model/run/gbt.py
+++ b/ToxCast_model/run/gbt.py
@@ -91,6 +91,10 @@ def main(fingerprint_type, file_path, model_save_path, assay_num, fp_path):
 
     x_train, x_test, y_train, y_test = train_test_split(x, y, test_size=0.2, shuffle=True, random_state=42)
 
+    # Save training fingerprints for DoA calculation
+    train_fp_path = os.path.join(model_save_path, "train_fps.csv")
+    x_train.to_csv(train_fp_path, index=False)
+
     params_dict = {
         'learning_rate': [0.001, 0.005, 0.01, 0.05, 0.1],
         'n_estimators': [5, 10, 50, 100, 130],

--- a/ToxCast_model/run/logistic.py
+++ b/ToxCast_model/run/logistic.py
@@ -91,6 +91,10 @@ def main(fingerprint_type, file_path, model_save_path, assay_num, fp_path):
 
     x_train, x_test, y_train, y_test = train_test_split(x, y, test_size=0.2, shuffle=True, random_state=42)
 
+    # Save training fingerprints for DoA calculation
+    train_fp_path = os.path.join(model_save_path, "train_fps.csv")
+    x_train.to_csv(train_fp_path, index=False)
+
     params_dict = {
         'C': [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 
               1, 2, 3, 4, 5, 7, 9, 11, 15, 20, 25, 30, 35, 40, 50, 100],

--- a/ToxCast_model/run/rf.py
+++ b/ToxCast_model/run/rf.py
@@ -91,6 +91,10 @@ def main(fingerprint_type, file_path, model_save_path, assay_num, fp_path):
 
     x_train, x_test, y_train, y_test = train_test_split(x, y, test_size=0.2, shuffle=True, random_state=42)
 
+    # Save training fingerprints for DoA calculation
+    train_fp_path = os.path.join(model_save_path, "train_fps.csv")
+    x_train.to_csv(train_fp_path, index=False)
+
     params_dict = {
         'n_estimators': [3, 5, 10, 15, 20, 30, 50, 90, 95, 100, 125, 130, 150],
         'criterion': ['gini'],

--- a/ToxCast_model/run/xgb.py
+++ b/ToxCast_model/run/xgb.py
@@ -77,6 +77,10 @@ def main(fingerprint_type, file_path, model_save_path, assay_num, fp_path):
 
     x_train, x_test, y_train, y_test = train_test_split(x, y, test_size=0.2, shuffle=True, random_state=42)
 
+    # Save training fingerprints for DoA calculation
+    train_fp_path = os.path.join(model_save_path, "train_fps.csv")
+    x_train.to_csv(train_fp_path, index=False)
+
     params_dict = {
         'min_child_weight': [1, 2, 3, 5],
         'max_depth': [3, 6, 9],

--- a/ToxCast_model/v.2/run_v.2/dt.py
+++ b/ToxCast_model/v.2/run_v.2/dt.py
@@ -104,6 +104,10 @@ def main(fingerprint_type, file_path, model_save_path, assay_num, fp_path, time_
         raise ValueError(f"Invalid time format for time_now: {time_now}. Expected format: 'HH-MM-SS'")
     
     x_train, x_test, y_train, y_test = train_test_split(x, y, test_size=0.2, shuffle=True, random_state=random_seed) #04.04 randomstate=42 제거 #04.07 randomeseed=time_now
+
+    # Save training fingerprints for DoA calculation
+    train_fp_path = os.path.join(model_save_path, "train_fps.csv")
+    x_train.to_csv(train_fp_path, index=False)
     
     
     # 저장 디렉토리 설정

--- a/ToxCast_model/v.2/run_v.2/gbt.py
+++ b/ToxCast_model/v.2/run_v.2/gbt.py
@@ -100,6 +100,10 @@ def main(fingerprint_type, file_path, model_save_path, assay_num, fp_path, time_
         raise ValueError(f"Invalid time format for time_now: {time_now}. Expected format: 'HH-MM-SS'")
     
     x_train, x_test, y_train, y_test = train_test_split(x, y, test_size=0.2, shuffle=True, random_state=random_seed) #04.07 randomstate=42 제거
+
+    # Save training fingerprints for DoA calculation
+    train_fp_path = os.path.join(model_save_path, "train_fps.csv")
+    x_train.to_csv(train_fp_path, index=False)
     
 
     # 저장 디렉토리 설정

--- a/ToxCast_model/v.2/run_v.2/logistic.py
+++ b/ToxCast_model/v.2/run_v.2/logistic.py
@@ -101,6 +101,10 @@ def main(fingerprint_type, file_path, model_save_path, assay_num, fp_path, time_
         raise ValueError(f"Invalid time format for time_now: {time_now}. Expected format: 'HH-MM-SS'")
     
     x_train, x_test, y_train, y_test = train_test_split(x, y, test_size=0.2, shuffle=True, random_state=random_seed) #04.07 randomstate=42 제거
+
+    # Save training fingerprints for DoA calculation
+    train_fp_path = os.path.join(model_save_path, "train_fps.csv")
+    x_train.to_csv(train_fp_path, index=False)
     
     
     # 저장 디렉토리 설정

--- a/ToxCast_model/v.2/run_v.2/rf.py
+++ b/ToxCast_model/v.2/run_v.2/rf.py
@@ -101,6 +101,10 @@ def main(fingerprint_type, file_path, model_save_path, assay_num, fp_path, time_
         raise ValueError(f"Invalid time format for time_now: {time_now}. Expected format: 'HH-MM-SS'")
     
     x_train, x_test, y_train, y_test = train_test_split(x, y, test_size=0.2, shuffle=True, random_state=random_seed) #04.07 randomstate=42 제거
+
+    # Save training fingerprints for DoA calculation
+    train_fp_path = os.path.join(model_save_path, "train_fps.csv")
+    x_train.to_csv(train_fp_path, index=False)
     
     
     # 저장 디렉토리 설정

--- a/ToxCast_model/v.2/run_v.2/xgb.py
+++ b/ToxCast_model/v.2/run_v.2/xgb.py
@@ -87,6 +87,10 @@ def main(fingerprint_type, file_path, model_save_path, assay_num, fp_path, time_
         raise ValueError(f"Invalid time format for time_now: {time_now}. Expected format: 'HH-MM-SS'")
     
     x_train, x_test, y_train, y_test = train_test_split(x, y, test_size=0.2, shuffle=True, random_state=random_seed) #04.07 randomstate=42 제거
+
+    # Save training fingerprints for DoA calculation
+    train_fp_path = os.path.join(model_save_path, "train_fps.csv")
+    x_train.to_csv(train_fp_path, index=False)
     
     
     # 저장 디렉토리 설정


### PR DESCRIPTION
## Summary
- store training fingerprints during model training
- calculate DoA using fingerprints from the model directory
- update calc_doa accordingly
- read MF from assay_list sheet when computing DoA

## Testing
- `python -m py_compile ToxCast_model/prediction/Predict_data.py ToxCast_model/prediction/calc_doa.py ToxCast_model/run/*.py ToxCast_model/v.2/run_v.2/*.py`


------
https://chatgpt.com/codex/tasks/task_e_687d8e9cdbd48320a79b3c7b5db62b50