### PR TITLE
Add DoA slurm support

### DIFF
--- a/ToxCast_model/prediction/calc_doa.py
+++ b/ToxCast_model/prediction/calc_doa.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+"""Calculate DoA values for prediction results and update the Excel file."""
+import argparse
+import json
+from pathlib import Path
+
+import pandas as pd
+import numpy as np
+
+from Predict_data import _tanimoto_max
+
+try:
+    from config import RESULTS_DIR, PREDICT_FP_PATH
+except ImportError as exc:
+    raise ImportError("Run from within ToxCast_model directory") from exc
+
+TRAIN_FP_BASE = Path("data/ToxCast_v.4.1_v.2/fingerprints")
+
+
+def _latest_result() -> Path:
+    dirs = [d for d in RESULTS_DIR.iterdir() if d.is_dir()]
+    if not dirs:
+        raise FileNotFoundError("No prediction results found under RESULTS_DIR")
+    latest = max(dirs, key=lambda p: p.stat().st_mtime)
+    files = list(latest.glob("*_prediction.xlsx"))
+    if len(files) != 1:
+        raise FileNotFoundError(f"Could not locate prediction excel in {latest}")
+    return files[0]
+
+
+def _load_dropidx(mf: str):
+    path = PREDICT_FP_PATH / f"{mf}_dropidx.csv"
+    if path.exists() and path.stat().st_size > 0:
+        try:
+            return pd.read_csv(path).iloc[:, 0].tolist()
+        except pd.errors.EmptyDataError:
+            return []
+    return []
+
+
+def _calc_doa_for_mf(mf: str, train_cache: dict):
+    if mf not in train_cache:
+        fp_path = TRAIN_FP_BASE / f"{mf}.csv"
+        train_cache[mf] = pd.read_csv(fp_path).astype(bool).values
+    train_fps = train_cache[mf]
+
+    pred_fp = pd.read_csv(PREDICT_FP_PATH / f"{mf}.csv")
+    drop_idx = _load_dropidx(mf)
+    if drop_idx:
+        pred_fp = pred_fp.drop(index=drop_idx).reset_index(drop=True)
+
+    return [
+        _tanimoto_max(fp.astype(bool), train_fps)
+        for fp in pred_fp.to_numpy()
+    ]
+
+
+def main(result_file: Path, metadata_file: Path) -> None:
+    df = pd.read_excel(result_file)
+    meta = json.loads(metadata_file.read_text())
+    assay_to_mf = {m["ASSAY"]: m["MF"] for m in meta}
+
+    train_cache = {}
+    doa_cache = {}
+
+    for assay, mf in assay_to_mf.items():
+        if mf not in doa_cache:
+            doa_cache[mf] = _calc_doa_for_mf(mf, train_cache)
+        doa_values = doa_cache[mf]
+        doa_col = f"{assay}_DoA"
+        if doa_col not in df.columns:
+            idx = df.columns.get_loc(assay) if assay in df.columns else len(df.columns)
+            df.insert(idx + 1, doa_col, doa_values)
+        else:
+            df[doa_col] = doa_values
+
+    df.to_excel(result_file, index=False)
+    print(f"DoA results updated in {result_file}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Calculate DoA for prediction results")
+    parser.add_argument("result_file", nargs="?", type=Path, help="Prediction result Excel file")
+    parser.add_argument("--metadata-file", type=Path, default=RESULTS_DIR / "metadata.json", help="Metadata JSON file")
+    args = parser.parse_args()
+
+    res = args.result_file or _latest_result()
+    meta = args.metadata_file
+    main(res, meta)

--- a/ToxCast_model/prediction/run_doa_slurm.sh
+++ b/ToxCast_model/prediction/run_doa_slurm.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+#SBATCH --job-name=GNN_launcher
+#SBATCH --partition=gpu1
+#SBATCH --gres=gpu:rtx3090:1
+#SBATCH --cpus-per-task=1
+#SBATCH --output=/dev/null
+#SBATCH --error=/dev/null
+
+set -e
+
+MAX_JOBS=20
+PARTITIONS=(gpu1 gpu2 gpu3 gpu4 gpu5 gpu6)
+DEFAULT_PART="gpu1"
+MAX_RUNNING_PER_PART=10
+GRES="gpu:rtx3090:1"
+CPUS_PER_TASK=8
+MEM_PER_TASK="16G"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+current_job_count() {
+    squeue -u "$USER" -h | wc -l
+}
+
+running_in_partition() {
+    local p="$1"
+    squeue -u "$USER" -p "$p" -t R -h | wc -l
+}
+
+has_idle_nodes() {
+    local p="$1"
+    sinfo -h -p "$p" -o "%D %t" \
+      | awk '$2=="idle"||$2=="mix"{sum+=$1}END{print sum}' \
+      | grep -q '[1-9]'
+}
+
+wait_for_slot() {
+    while [ "$(current_job_count)" -ge "$MAX_JOBS" ]; do
+        echo "▶ waiting for submit slot ($(current_job_count)/$MAX_JOBS)…"
+        sleep 30
+    done
+}
+
+RESULT_FILE="$1"
+METADATA_FILE="$2"
+
+for p in "${PARTITIONS[@]}"; do
+    if [ "$(running_in_partition "$p")" -lt "$MAX_RUNNING_PER_PART" ] && has_idle_nodes "$p"; then
+        PART="$p"
+        break
+    fi
+done
+PART=${PART:-$DEFAULT_PART}
+
+wait_for_slot
+
+sbatch --partition="$PART" --gres="$GRES" --cpus-per-task="$CPUS_PER_TASK" --mem="$MEM_PER_TASK" \
+  --wrap="cd \"$SCRIPT_DIR/..\" && PYTHONPATH=. python prediction/calc_doa.py \"$RESULT_FILE\" --metadata-file \"$METADATA_FILE\""

--- a/run_prediction.sh
+++ b/run_prediction.sh
@@ -8,7 +8,19 @@ step="${1:-predict}"
 
 if [ "$step" = "doa" ]; then
     cd "$model_dir" || exit 1
-    PYTHONPATH=. python prediction/calc_doa.py
+    result_file="$2"
+    metadata_file="$3"
+    if [ -z "$result_file" ]; then
+        results_dir=$(python - <<'PY'
+import config
+print(config.RESULTS_DIR)
+PY
+)
+        latest_dir=$(ls -dt "$results_dir"/* | head -n 1)
+        result_file=$(ls "$latest_dir"/*_prediction.xlsx | head -n 1)
+        metadata_file="$results_dir/metadata.json"
+    fi
+    bash prediction/run_doa_slurm.sh "$result_file" "$metadata_file"
     exit $?
 fi
 
@@ -44,6 +56,15 @@ case "$mode" in
         ;;
     prediction)
         PYTHONPATH=. python prediction/Predict_data.py --skip-doa
+        results_dir=$(python - <<'PY'
+import config
+print(config.RESULTS_DIR)
+PY
+)
+        latest_dir=$(ls -dt "$results_dir"/* | head -n 1)
+        result_file=$(ls "$latest_dir"/*_prediction.xlsx | head -n 1)
+        metadata_file="$results_dir/metadata.json"
+        bash prediction/run_doa_slurm.sh "$result_file" "$metadata_file"
         ;;
     *)
         echo "Unknown mode: $mode"


### PR DESCRIPTION
## Summary
- implement `calc_doa.py` for post‑prediction DoA calculation
- add `run_doa_slurm.sh` to submit DoA jobs via slurm
- update `run_prediction.sh` to launch DoA jobs after prediction or when invoked with `doa` step

## Testing
- `python -m py_compile ToxCast_model/prediction/calc_doa.py`

------
https://chatgpt.com/codex/tasks/task_e_687da87b38f88320970e569658bca409