### PR TITLE
Apply train/test split when computing DoA

### DIFF
--- a/ToxCast_model/prediction/Predict_data.py
+++ b/ToxCast_model/prediction/Predict_data.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from datetime import datetime
 import json
 import numpy as np
+from sklearn.model_selection import train_test_split
 
 
 def _tanimoto_max(test_fp: np.ndarray, train_fps: np.ndarray) -> float:
@@ -130,11 +131,23 @@ if __name__ == "__main__":
             # DoA 계산을 위한 학습 fingerprint 로드
             if mf_type not in train_fp_cache:
                 train_fp_path = train_fp_base / f"{mf_type}.csv"
+                dropidx_path = train_fp_base / f"{mf_type}_dropidx.csv"
                 if not train_fp_path.exists():
                     print(f"학습 fingerprint 파일이 존재하지 않습니다: {train_fp_path}")
                     train_fp_cache[mf_type] = None
                 else:
-                    train_fp_cache[mf_type] = pd.read_csv(train_fp_path).astype(bool).values
+                    train_df = pd.read_csv(train_fp_path)
+                    if dropidx_path.exists() and dropidx_path.stat().st_size > 0:
+                        try:
+                            drop_idx = pd.read_csv(dropidx_path).iloc[:, 0].tolist()
+                        except pd.errors.EmptyDataError:
+                            drop_idx = []
+                        if drop_idx:
+                            train_df = train_df.drop(index=drop_idx).reset_index(drop=True)
+                    train_df, _ = train_test_split(
+                        train_df, test_size=0.2, shuffle=True, random_state=42
+                    )
+                    train_fp_cache[mf_type] = train_df.astype(bool).values
 
             train_fps = train_fp_cache.get(mf_type)
             if train_fps is not None:

--- a/ToxCast_model/prediction/calc_doa.py
+++ b/ToxCast_model/prediction/calc_doa.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pandas as pd
 import numpy as np
+from sklearn.model_selection import train_test_split
 
 from Predict_data import _tanimoto_max
 
@@ -41,7 +42,17 @@ def _load_dropidx(mf: str):
 def _calc_doa_for_mf(mf: str, train_cache: dict):
     if mf not in train_cache:
         fp_path = TRAIN_FP_BASE / f"{mf}.csv"
-        train_cache[mf] = pd.read_csv(fp_path).astype(bool).values
+        drop_path = TRAIN_FP_BASE / f"{mf}_dropidx.csv"
+        train_df = pd.read_csv(fp_path)
+        if drop_path.exists() and drop_path.stat().st_size > 0:
+            try:
+                drop_idx = pd.read_csv(drop_path).iloc[:, 0].tolist()
+            except pd.errors.EmptyDataError:
+                drop_idx = []
+            if drop_idx:
+                train_df = train_df.drop(index=drop_idx).reset_index(drop=True)
+        train_df, _ = train_test_split(train_df, test_size=0.2, shuffle=True, random_state=42)
+        train_cache[mf] = train_df.astype(bool).values
     train_fps = train_cache[mf]
 
     pred_fp = pd.read_csv(PREDICT_FP_PATH / f"{mf}.csv")


### PR DESCRIPTION
## Summary
- ensure DoA uses the same training split as models by splitting the original fingerprint set
- import `train_test_split` for prediction scripts

## Testing
- `python -m compileall -q ToxCast_model/prediction/Predict_data.py ToxCast_model/prediction/calc_doa.py`

------
https://chatgpt.com/codex/tasks/task_e_687dde2f6ea083209e5b6a5c0aa17b50