### PR TITLE
Fix prediction result lookup and allow ampersand directory search

### DIFF
--- a/ToxCast_model/prediction/Predict_data.py
+++ b/ToxCast_model/prediction/Predict_data.py
@@ -79,6 +79,10 @@ if __name__ == "__main__":
             # locate model automatically from best F1 directory
             pattern = f"{model_path_base}/{assay_name}_*/{assay_name}_best_model_*.joblib"
             matches = list(Path(model_path_base).glob(f"{assay_name}_*/{assay_name}_best_model_*.joblib"))
+            if not matches:
+                alt_name = assay_name.replace("_", "&")
+                pattern = f"{model_path_base}/{alt_name}_*/{alt_name}_best_model_*.joblib"
+                matches = list(Path(model_path_base).glob(f"{alt_name}_*/{alt_name}_best_model_*.joblib"))
             if len(matches) != 1:
                 msg = f"모델 파일을 찾지 못했습니다: {pattern}"
                 print(msg)

--- a/run_prediction.sh
+++ b/run_prediction.sh
@@ -62,7 +62,7 @@ print(config.RESULTS_DIR)
 PY
 )
         latest_dir=$(ls -dt "$results_dir"/* | head -n 1)
-        result_file=$(ls "$results_dir"/*_prediction.xlsx | head -n 1)
+        result_file=$(ls "$latest_dir"/*_prediction.xlsx | head -n 1)
         metadata_file="$results_dir/metadata.json"
         bash prediction/run_doa_slurm.sh "$result_file" "$metadata_file"
         ;;


### PR DESCRIPTION
## Summary
- fix run_prediction.sh to locate prediction excel inside latest results directory
- allow ampersand/underscore interchange when auto-discovering model files

## Testing
- `python -m py_compile ToxCast_model/prediction/Predict_data.py`
- `bash -n run_prediction.sh`


------
https://chatgpt.com/codex/tasks/task_e_687de49738ac8320b811ff883e61815c