### PR TITLE
Enhance DoA job logging and submission

### DIFF
--- a/ToxCast_model/prediction/calc_doa.py
+++ b/ToxCast_model/prediction/calc_doa.py
@@ -3,6 +3,9 @@
 import argparse
 import json
 from pathlib import Path
+from datetime import datetime
+
+from tqdm import tqdm
 
 import pandas as pd
 import numpy as np
@@ -39,7 +42,7 @@ def _load_dropidx(mf: str):
     return []
 
 
-def _calc_doa_for_mf(mf: str, train_cache: dict):
+def _calc_doa_for_mf(mf: str, train_cache: dict, log_file=None):
     if mf not in train_cache:
         fp_path = TRAIN_FP_BASE / f"{mf}.csv"
         drop_path = TRAIN_FP_BASE / f"{mf}_dropidx.csv"
@@ -60,9 +63,12 @@ def _calc_doa_for_mf(mf: str, train_cache: dict):
     if drop_idx:
         pred_fp = pred_fp.drop(index=drop_idx).reset_index(drop=True)
 
+    iterator = pred_fp.to_numpy()
+    if log_file is not None:
+        iterator = tqdm(iterator, desc=f"{mf}", file=log_file)
     return [
         _tanimoto_max(fp.astype(bool), train_fps)
-        for fp in pred_fp.to_numpy()
+        for fp in iterator
     ]
 
 
@@ -71,19 +77,24 @@ def main(result_file: Path, metadata_file: Path) -> None:
     meta = json.loads(metadata_file.read_text())
     assay_to_mf = {m["ASSAY"]: m["MF"] for m in meta}
 
-    train_cache = {}
-    doa_cache = {}
-
-    for assay, mf in assay_to_mf.items():
-        if mf not in doa_cache:
-            doa_cache[mf] = _calc_doa_for_mf(mf, train_cache)
-        doa_values = doa_cache[mf]
-        doa_col = f"{assay}_DoA"
-        if doa_col not in df.columns:
-            idx = df.columns.get_loc(assay) if assay in df.columns else len(df.columns)
-            df.insert(idx + 1, doa_col, doa_values)
-        else:
-            df[doa_col] = doa_values
+    log_path = result_file.parent / "doa_progress.log"
+    with open(log_path, "w") as log_f:
+        log_f.write(f"Start time: {datetime.now().isoformat()}\n")
+        train_cache = {}
+        doa_cache = {}
+        with tqdm(total=len(assay_to_mf), desc="assays", file=log_f) as bar:
+            for assay, mf in assay_to_mf.items():
+                if mf not in doa_cache:
+                    doa_cache[mf] = _calc_doa_for_mf(mf, train_cache, log_f)
+                doa_values = doa_cache[mf]
+                doa_col = f"{assay}_DoA"
+                if doa_col not in df.columns:
+                    idx = df.columns.get_loc(assay) if assay in df.columns else len(df.columns)
+                    df.insert(idx + 1, doa_col, doa_values)
+                else:
+                    df[doa_col] = doa_values
+                log_f.flush()
+                bar.update(1)
 
     df.to_excel(result_file, index=False)
     print(f"DoA results updated in {result_file}")

--- a/ToxCast_model/prediction/run_doa_slurm.sh
+++ b/ToxCast_model/prediction/run_doa_slurm.sh
@@ -9,51 +9,32 @@
 
 set -e
 
-MAX_JOBS=20
-PARTITIONS=(gpu1 gpu2 gpu3 gpu4 gpu5 gpu6)
-DEFAULT_PART="gpu1"
-MAX_RUNNING_PER_PART=10
+PARTITIONS=(gpu6 gpu1 gpu2 gpu3 gpu4 gpu5)
 GRES="gpu:rtx3090:1"
 CPUS_PER_TASK=8
 MEM_PER_TASK="16G"
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
-current_job_count() {
-    squeue -u "$USER" -h | wc -l
-}
-
-running_in_partition() {
-    local p="$1"
-    squeue -u "$USER" -p "$p" -t R -h | wc -l
-}
-
-has_idle_nodes() {
-    local p="$1"
-    sinfo -h -p "$p" -o "%D %t" \
-      | awk '$2=="idle"||$2=="mix"{sum+=$1}END{print sum}' \
-      | grep -q '[1-9]'
-}
-
-wait_for_slot() {
-    while [ "$(current_job_count)" -ge "$MAX_JOBS" ]; do
-        echo "▶ waiting for submit slot ($(current_job_count)/$MAX_JOBS)…"
-        sleep 30
-    done
-}
-
 RESULT_FILE="$1"
 METADATA_FILE="$2"
 
+JOBID=""
 for p in "${PARTITIONS[@]}"; do
-    if [ "$(running_in_partition "$p")" -lt "$MAX_RUNNING_PER_PART" ] && has_idle_nodes "$p"; then
-        PART="$p"
-        break
+    JOBID=$(sbatch --parsable --partition="$p" --gres="$GRES" --cpus-per-task="$CPUS_PER_TASK" --mem="$MEM_PER_TASK" \
+      --wrap="cd \"$SCRIPT_DIR/..\" && PYTHONPATH=. python prediction/calc_doa.py \"$RESULT_FILE\" --metadata-file \"$METADATA_FILE\"")
+    sleep 2
+    info=$(squeue -j "$JOBID" -h -o '%T %R')
+    state=$(echo "$info" | awk '{print $1}')
+    if [ "$state" != "PD" ]; then
+        echo "Job $JOBID running on $(echo "$info" | awk '{print $2}')"
+        exit 0
     fi
+    scancel "$JOBID"
+    echo "Partition $p busy, trying next..."
+    sleep 10
 done
-PART=${PART:-$DEFAULT_PART}
 
-wait_for_slot
-
-sbatch --partition="$PART" --gres="$GRES" --cpus-per-task="$CPUS_PER_TASK" --mem="$MEM_PER_TASK" \
+LAST_PART=${PARTITIONS[$(( ${#PARTITIONS[@]} - 1 ))]}
+sbatch --partition="$LAST_PART" --gres="$GRES" --cpus-per-task="$CPUS_PER_TASK" --mem="$MEM_PER_TASK" \
   --wrap="cd \"$SCRIPT_DIR/..\" && PYTHONPATH=. python prediction/calc_doa.py \"$RESULT_FILE\" --metadata-file \"$METADATA_FILE\""


### PR DESCRIPTION
## Summary
- log DoA calculation progress in a `doa_progress.log` file
- show progress bars with ETA using `tqdm`
- submit DoA jobs sequentially across GPU partitions

## Testing
- `python -m py_compile ToxCast_model/prediction/calc_doa.py`
- `shellcheck not available`

------
https://chatgpt.com/codex/tasks/task_e_687ded016a808320b19c525c923a4b9a