### PR TITLE
Add AEID handling for training results

### DIFF
--- a/ToxCast_model/update_training_results.py
+++ b/ToxCast_model/update_training_results.py
@@ -1,0 +1,96 @@
+import json
+import sys
+from pathlib import Path
+import pandas as pd
+from openpyxl import load_workbook
+
+project_dir = Path(sys.argv[1])
+input_excel = (
+    Path(sys.argv[2])
+    if len(sys.argv) > 2
+    else project_dir / "training_input_template.xlsx"
+)
+metadata_file = (
+    Path(sys.argv[3]) if len(sys.argv) > 3 else project_dir / "metadata.json"
+)
+results_excel = project_dir / "results" / "training_results_template.xlsx"
+
+# load metadata
+with open(metadata_file, "r", encoding="utf-8") as f:
+    records = json.load(f)
+if not records:
+    sys.exit()
+
+# group by assay
+by_assay = {}
+for r in records:
+    by_assay.setdefault(r["assay_name"], []).append(r)
+
+# compute training stats using pandas
+# first row holds AEID numbers, second row holds assay names
+aeid_row = pd.read_excel(input_excel, sheet_name="data", nrows=1, header=None).iloc[
+    0, 1:
+]
+train_df = pd.read_excel(input_excel, sheet_name="data", header=1)
+aeid_map = dict(zip(train_df.columns, aeid_row))
+
+# open workbook for update
+wb = load_workbook(results_excel)
+f1_ws = wb["F1"]
+auc_ws = wb["AUC"]
+
+# ensure AEID column exists in results template
+if f1_ws["B1"].value != "AEID":
+    f1_ws.insert_cols(2)
+    f1_ws["B1"] = "AEID"
+if auc_ws["B1"].value != "AEID":
+    auc_ws.insert_cols(2)
+    auc_ws["B1"] = "AEID"
+
+for assay in by_assay:
+    series = train_df[assay].dropna()
+    train_count = len(series)
+    pos_ratio = series.mean() * 100 if len(series) > 0 else 0
+    best_f1 = max(by_assay[assay], key=lambda r: r.get("F1", 0))
+    best_auc = max(by_assay[assay], key=lambda r: r.get("AUC", 0))
+    aeid = aeid_map.get(assay, "")
+    row_f1 = [
+        assay,
+        aeid,
+        train_count,
+        f"{pos_ratio:.2f}",
+        best_f1["MF"],
+        best_f1["Model"],
+        best_f1.get("F1"),
+        best_f1.get("Precision"),
+        best_f1.get("Recall"),
+        best_f1.get("AUC"),
+        best_f1.get("Accuracy"),
+        best_f1.get("valF1"),
+        "",
+        "",
+        best_f1.get("valAUC"),
+        "",
+    ]
+    f1_ws.append(row_f1)
+    row_auc = [
+        assay,
+        aeid,
+        train_count,
+        f"{pos_ratio:.2f}",
+        best_auc["MF"],
+        best_auc["Model"],
+        best_auc.get("F1"),
+        best_auc.get("Precision"),
+        best_auc.get("Recall"),
+        best_auc.get("AUC"),
+        best_auc.get("Accuracy"),
+        best_auc.get("valF1"),
+        "",
+        "",
+        best_auc.get("valAUC"),
+        "",
+    ]
+    auc_ws.append(row_auc)
+
+wb.save(results_excel)

--- a/run_training.sh
+++ b/run_training.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+# Convenience script to train models for a project directory
+set -e
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+model_dir="$script_dir/ToxCast_model"
+project_dir="$1"
+if [ -z "$project_dir" ]; then
+    echo "Usage: $0 <PROJECT_DIR>" >&2
+    exit 1
+fi
+
+input_excel="$project_dir/training_input_template.xlsx"
+results_dir="$project_dir/results"
+logs_dir="$project_dir/logs"
+fp_dir="$project_dir/fingerprints"
+metadata_file="$project_dir/metadata.json"
+mkdir -p "$results_dir" "$logs_dir" "$fp_dir"
+: > "$metadata_file"
+
+mapfile -t assays < <(python - "$input_excel" <<'PY'
+import sys, zipfile, xml.etree.ElementTree as ET
+xlsx=sys.argv[1]
+with zipfile.ZipFile(xlsx) as z:
+    shared=z.read('xl/sharedStrings.xml').decode()
+    sheet=z.read('xl/worksheets/sheet1.xml').decode()
+ss=ET.fromstring(shared)
+strings=[s.find('{http://schemas.openxmlformats.org/spreadsheetml/2006/main}t').text for s in ss]
+ns={'a':'http://schemas.openxmlformats.org/spreadsheetml/2006/main'}
+root=ET.fromstring(sheet)
+row=root.find('.//a:row[@r="2"]', ns)
+vals=[]
+for c in row.findall('a:c', ns):
+    v=c.find('a:v', ns)
+    if v is None:
+        val=''
+    else:
+        val=v.text
+    if c.get('t')=='s':
+        val=strings[int(val)]
+    vals.append(val)
+print('\n'.join(vals[1:]))
+PY
+)
+
+fingerprints=(MACCS Morgan Layered Pattern RDKit)
+models=(rf logistic xgb gbt dt)
+
+assay_index=0
+for assay in "${assays[@]}"; do
+    for fp in "${fingerprints[@]}"; do
+        for model in "${models[@]}"; do
+            save_dir="$results_dir/${assay}_${fp}_${model}"
+            mkdir -p "$save_dir"
+            log_file="$logs_dir/${assay}_${fp}_${model}.log"
+            start_time=$(date +%s)
+            PYTHONPATH="$model_dir" python "$model_dir/run/${model}.py" \
+                --fingerprint_type "$fp" \
+                --file_path "$input_excel" \
+                --model_save_path "$save_dir" \
+                --assay_num "$assay_index" \
+                --fp_path "$fp_dir" \
+                >"$log_file" 2>&1
+            end_time=$(date +%s)
+            duration=$((end_time - start_time))
+            test_f1=$(grep -o "Test F1 Score: [0-9.e+-]*" "$log_file" | awk '{print $4}' | tail -n1)
+            val_f1=$(grep -o "Validation F1 Score: [0-9.e+-]*" "$log_file" | awk '{print $4}' | tail -n1)
+            test_auc=$(grep -o "Test AUC: [0-9.e+-]*" "$log_file" | awk '{print $3}' | tail -n1)
+            val_auc=$(grep -o "Validation AUC: [0-9.e+-]*" "$log_file" | awk '{print $3}' | tail -n1)
+            precision=$(grep -o "Test Precision: [0-9.e+-]*" "$log_file" | awk '{print $4}' | tail -n1)
+            recall=$(grep -o "Test Recall: [0-9.e+-]*" "$log_file" | awk '{print $4}' | tail -n1)
+            accuracy=$(grep -o "Test Accuracy: [0-9.e+-]*" "$log_file" | awk '{print $4}' | tail -n1)
+            python - "$metadata_file" <<PY
+import json,sys
+f=sys.argv[1]
+try:
+    data=json.load(open(f))
+except Exception:
+    data=[]
+rec={"assay_name":"$assay","MF":"$fp","Model":"$model","duration":$duration,
+     "F1":float("${test_f1:-0}"),"valF1":float("${val_f1:-0}"),
+     "AUC":float("${test_auc:-0}"),"valAUC":float("${val_auc:-0}"),
+     "Precision":float("${precision:-0}"),"Recall":float("${recall:-0}"),"Accuracy":float("${accuracy:-0}")}
+data.append(rec)
+json.dump(data,open(f,'w'),indent=2)
+PY
+        done
+    done
+    assay_index=$((assay_index+1))
+done
+
+python "$model_dir/update_training_results.py" "$project_dir" "$input_excel" "$metadata_file"


### PR DESCRIPTION
## Summary
- generate AEID/assay mapping from training input
- ensure AEID column exists in results workbook and record it per assay

## Testing
- `pytest -q` *(no tests discovered)*

------
https://chatgpt.com/codex/tasks/task_e_6887012006508320a7551660daea0bef