### PR TITLE
Restore DoA calculation utilities

### DIFF
--- a/ToxCast_model/prediction/calc_doa.py
+++ b/ToxCast_model/prediction/calc_doa.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python
+"""Calculate DoA values for prediction results and update the Excel file."""
+import argparse
+import json
+from pathlib import Path
+from datetime import datetime
+
+from tqdm import tqdm
+
+import pandas as pd
+import numpy as np
+from sklearn.model_selection import train_test_split
+
+from Predict_data import _tanimoto_max
+
+try:
+    from config import RESULTS_DIR
+except ImportError as exc:
+    raise ImportError("Run from within ToxCast_model directory") from exc
+
+TRAIN_FP_BASE = Path("data/ToxCast_v.4.1_v.2/fingerprints")
+
+
+def _latest_result() -> Path:
+    dirs = [d for d in RESULTS_DIR.iterdir() if d.is_dir()]
+    if not dirs:
+        raise FileNotFoundError("No prediction results found under RESULTS_DIR")
+    latest = max(dirs, key=lambda p: p.stat().st_mtime)
+    files = list(latest.glob("*_prediction.xlsx"))
+    if len(files) != 1:
+        raise FileNotFoundError(f"Could not locate prediction excel in {latest}")
+    return files[0]
+
+
+def _load_dropidx(mf: str, fp_dir: Path):
+    path = fp_dir / f"{mf}_dropidx.csv"
+    if path.exists() and path.stat().st_size > 0:
+        try:
+            return pd.read_csv(path).iloc[:, 0].tolist()
+        except pd.errors.EmptyDataError:
+            return []
+    return []
+
+
+def _calc_doa_for_mf(mf: str, fp_dir: Path, train_cache: dict, log_file=None):
+    if mf not in train_cache:
+        fp_path = TRAIN_FP_BASE / f"{mf}.csv"
+        drop_path = TRAIN_FP_BASE / f"{mf}_dropidx.csv"
+        train_df = pd.read_csv(fp_path)
+        if drop_path.exists() and drop_path.stat().st_size > 0:
+            try:
+                drop_idx = pd.read_csv(drop_path).iloc[:, 0].tolist()
+            except pd.errors.EmptyDataError:
+                drop_idx = []
+            if drop_idx:
+                train_df = train_df.drop(index=drop_idx).reset_index(drop=True)
+        train_df, _ = train_test_split(train_df, test_size=0.2, shuffle=True, random_state=42)
+        train_cache[mf] = train_df.astype(bool).values
+    train_fps = train_cache[mf]
+
+    pred_fp = pd.read_csv(fp_dir / f"{mf}.csv")
+    drop_idx = _load_dropidx(mf, fp_dir)
+    if drop_idx:
+        pred_fp = pred_fp.drop(index=drop_idx).reset_index(drop=True)
+
+    iterator = pred_fp.to_numpy()
+    if log_file is not None:
+        iterator = tqdm(iterator, desc=f"{mf}", file=log_file)
+    return [
+        _tanimoto_max(fp.astype(bool), train_fps)
+        for fp in iterator
+    ]
+
+
+def main(result_file: Path, metadata_file: Path) -> None:
+    df = pd.read_excel(result_file)
+    meta = json.loads(metadata_file.read_text())
+    fp_dir = result_file.parents[2] / "fingerprints"
+    assay_to_mf = {m["ASSAY"]: m["MF"] for m in meta}
+
+    log_path = result_file.parent / "doa_progress.log"
+    with open(log_path, "w") as log_f:
+        log_f.write(f"Start time: {datetime.now().isoformat()}\n")
+        train_cache = {}
+        doa_cache = {}
+        with tqdm(total=len(assay_to_mf), desc="assays", file=log_f) as bar:
+            for assay, mf in assay_to_mf.items():
+                if mf not in doa_cache:
+                    doa_cache[mf] = _calc_doa_for_mf(mf, fp_dir, train_cache, log_f)
+                doa_values = doa_cache[mf]
+                if len(doa_values) != len(df):
+                    doa_values = doa_values[: len(df)]
+                doa_col = f"{assay}_DoA"
+                if doa_col not in df.columns:
+                    idx = df.columns.get_loc(assay) if assay in df.columns else len(df.columns)
+                    df.insert(idx + 1, doa_col, doa_values)
+                else:
+                    df[doa_col] = doa_values
+                log_f.flush()
+                bar.update(1)
+
+    df.to_excel(result_file, index=False)
+    print(f"DoA results updated in {result_file}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Calculate DoA for prediction results")
+    parser.add_argument("result_file", nargs="?", type=Path, help="Prediction result Excel file")
+    parser.add_argument("--metadata-file", type=Path, default=RESULTS_DIR / "metadata.json", help="Metadata JSON file")
+    args = parser.parse_args()
+
+    res = args.result_file or _latest_result()
+    meta = args.metadata_file
+    main(res, meta)

--- a/ToxCast_model/prediction/calc_train_doa.py
+++ b/ToxCast_model/prediction/calc_train_doa.py
@@ -1,0 +1,93 @@
+import argparse
+import pandas as pd
+import numpy as np
+from pathlib import Path
+
+from Predict_data import _tanimoto_max
+
+try:
+    from config import TRAIN_FILE_PATH
+except ImportError:
+    raise ImportError('Run from within ToxCast_model directory')
+
+
+def load_assay_mf(excel_path: Path, assay_name: str) -> str:
+    """Return fingerprint type (MF) for assay_name from assay_list sheet."""
+    assay_df = pd.read_excel(excel_path, sheet_name="assay_list")
+    row = assay_df[assay_df["assay_name"] == assay_name]
+    if row.empty:
+        raise KeyError(f"assay_name {assay_name} not found in assay_list")
+    return row.iloc[0]["MF"]
+
+
+def load_training_fps(excel_path: Path, fp_base: Path, assay: str, mf: str) -> np.ndarray:
+    fp_path = fp_base / f"{mf}.csv"
+    drop_path = fp_base / f"{mf}_dropidx.csv"
+
+    x = pd.read_csv(fp_path)
+    drop_idx = []
+    if drop_path.exists() and drop_path.stat().st_size > 0:
+        try:
+            drop_idx = pd.read_csv(drop_path).iloc[:, 0].tolist()
+        except pd.errors.EmptyDataError:
+            drop_idx = []
+    if drop_idx:
+        x = x.drop(index=drop_idx).reset_index(drop=True)
+
+    df = pd.read_excel(excel_path, sheet_name="data")
+    y = df[assay]
+    if drop_idx:
+        y = y.drop(index=drop_idx).reset_index(drop=True)
+
+    na_idx = y[y.isnull()].index
+    if len(na_idx) > 0:
+        x = x.drop(index=na_idx).reset_index(drop=True)
+        y = y.drop(index=na_idx).reset_index(drop=True)
+
+    from sklearn.model_selection import train_test_split
+
+    train_x, _, _, _ = train_test_split(
+        x, y, test_size=0.2, shuffle=True, random_state=42
+    )
+
+    return train_x.astype(bool).to_numpy()
+
+
+def calc_doa_matrix(train_fps: np.ndarray) -> np.ndarray:
+    doa_values = []
+    for i, fp in enumerate(train_fps):
+        ref = np.delete(train_fps, i, axis=0)
+        if ref.size == 0:
+            doa_values.append(1.0)
+        else:
+            doa_values.append(_tanimoto_max(fp, ref))
+    return np.array(doa_values)
+
+
+def main(assay_name: str, excel_path: Path, fp_base: Path) -> None:
+    mf = load_assay_mf(excel_path, assay_name)
+    train_fps = load_training_fps(excel_path, fp_base, assay_name, mf)
+    doa = calc_doa_matrix(train_fps)
+
+    out_path = fp_base / f"{assay_name}_{mf}_train_doa.csv"
+    pd.DataFrame({"DoA": doa}).to_csv(out_path, index=False)
+    print(f"Training DoA saved to {out_path}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Calculate DoA for training data")
+    parser.add_argument("assay", help="Assay name to calculate DoA for")
+    parser.add_argument(
+        "--excel-path",
+        type=Path,
+        default=TRAIN_FILE_PATH,
+        help="Excel file with data and assay_list sheets",
+    )
+    parser.add_argument(
+        "--fp-base",
+        type=Path,
+        default=Path("data/ToxCast_v.4.1_v.2/fingerprints"),
+        help="Base directory containing training fingerprints",
+    )
+    args = parser.parse_args()
+    main(args.assay, args.excel_path, args.fp_base)


### PR DESCRIPTION
## Summary
- restore `calc_doa.py` for prediction Domain of Applicability updates
- restore `calc_train_doa.py` for computing training DoA matrices

## Testing
- `python -m py_compile ToxCast_model/prediction/calc_doa.py ToxCast_model/prediction/calc_train_doa.py`

------
https://chatgpt.com/codex/tasks/task_e_6887100242bc832085639cc9746b81b0