### PR TITLE
Add launcher script

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ ToxCast_model/              # Main source code
 7. Run the pipeline from the project root:
 
 ```bash
-bash run_prediction.sh
+bash launcher.sh
 ```
 
 ### Local usage

--- a/launcher.sh
+++ b/launcher.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Unified launcher for training or prediction
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+mode=$(python - <<'PY'
+import config
+print(config.OBJECTS[config.OBJECT])
+PY
+)
+
+case "$mode" in
+    training)
+        bash "$script_dir/run_training.sh" "$@"
+        ;;
+    prediction)
+        bash "$script_dir/run_prediction.sh" "$@"
+        ;;
+    *)
+        echo "Unknown OBJECT mode: $mode" >&2
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
## Summary
- add `launcher.sh` to switch between prediction and training
- update README to show `bash launcher.sh`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68871580ab748320a8373bceec1ea640