### PR TITLE
Improve assay name extraction and error reporting

### DIFF
--- a/ToxCast_model/update_training_results.py
+++ b/ToxCast_model/update_training_results.py
@@ -51,46 +51,59 @@ for assay in by_assay:
     series = train_df[assay].dropna()
     train_count = len(series)
     pos_ratio = series.mean() * 100 if len(series) > 0 else 0
-    best_f1 = max(by_assay[assay], key=lambda r: r.get("F1", 0))
-    best_auc = max(by_assay[assay], key=lambda r: r.get("AUC", 0))
+    valid_records = [r for r in by_assay[assay] if not r.get("Error")]
+    error_records = [r for r in by_assay[assay] if r.get("Error")]
+    best_f1 = max(valid_records, key=lambda r: r.get("F1", 0)) if valid_records else None
+    best_auc = max(valid_records, key=lambda r: r.get("AUC", 0)) if valid_records else None
+    error_msg = error_records[0]["Error"] if error_records else ""
     aeid = aeid_map.get(assay, "")
-    row_f1 = [
-        assay,
-        aeid,
-        train_count,
-        f"{pos_ratio:.2f}",
-        best_f1["MF"],
-        best_f1["Model"],
-        best_f1.get("F1"),
-        best_f1.get("Precision"),
-        best_f1.get("Recall"),
-        best_f1.get("AUC"),
-        best_f1.get("Accuracy"),
-        best_f1.get("valF1"),
-        "",
-        "",
-        best_f1.get("valAUC"),
-        "",
-    ]
-    f1_ws.append(row_f1)
-    row_auc = [
-        assay,
-        aeid,
-        train_count,
-        f"{pos_ratio:.2f}",
-        best_auc["MF"],
-        best_auc["Model"],
-        best_auc.get("F1"),
-        best_auc.get("Precision"),
-        best_auc.get("Recall"),
-        best_auc.get("AUC"),
-        best_auc.get("Accuracy"),
-        best_auc.get("valF1"),
-        "",
-        "",
-        best_auc.get("valAUC"),
-        "",
-    ]
-    auc_ws.append(row_auc)
+    if best_f1:
+        f1_value = error_msg if error_msg else best_f1.get("F1")
+        row_f1 = [
+            assay,
+            aeid,
+            train_count,
+            f"{pos_ratio:.2f}",
+            best_f1["MF"],
+            best_f1["Model"],
+            f1_value,
+            best_f1.get("Precision"),
+            best_f1.get("Recall"),
+            best_f1.get("AUC"),
+            best_f1.get("Accuracy"),
+            best_f1.get("valF1"),
+            "",
+            "",
+            best_f1.get("valAUC"),
+            "",
+        ]
+        f1_ws.append(row_f1)
+    else:
+        row_f1 = [assay, aeid, train_count, f"{pos_ratio:.2f}", "", "", error_msg, "", "", "", "", "", "", "", "", ""]
+        f1_ws.append(row_f1)
+    if best_auc:
+        auc_value = error_msg if error_msg else best_auc.get("AUC")
+        row_auc = [
+            assay,
+            aeid,
+            train_count,
+            f"{pos_ratio:.2f}",
+            best_auc["MF"],
+            best_auc["Model"],
+            best_auc.get("F1"),
+            best_auc.get("Precision"),
+            best_auc.get("Recall"),
+            auc_value,
+            best_auc.get("Accuracy"),
+            best_auc.get("valF1"),
+            "",
+            "",
+            best_auc.get("valAUC"),
+            "",
+        ]
+        auc_ws.append(row_auc)
+    else:
+        row_auc = [assay, aeid, train_count, f"{pos_ratio:.2f}", "", "", "", "", "", error_msg, "", "", "", "", "", ""]
+        auc_ws.append(row_auc)
 
 wb.save(results_excel)

--- a/slurm/run_training.sh
+++ b/slurm/run_training.sh
@@ -90,7 +90,7 @@ for c in row.findall('a:c', ns):
     if c.get('t')=='s':
         val=strings[int(val)]
     vals.append(val)
-print('\n'.join(vals[1:]))
+print('\n'.join(vals[2:]))
 PY
 )
 
@@ -106,6 +106,7 @@ for assay in "${assays[@]}"; do
             log_file="$logs_dir/${assay}_${fp}_${model}.log"
             echo "[$(date '+%F %T')] START ${assay}_${fp}_${model}" >> "$slurm_out"
             start_time=$(date +%s)
+            set +e
             PYTHONPATH="$model_dir" python "$model_dir/run/${model}.py" \
                 --fingerprint_type "$fp" \
                 --file_path "$input_excel" \
@@ -113,9 +114,15 @@ for assay in "${assays[@]}"; do
                 --assay_num "$assay_index" \
                 --fp_path "$fp_dir" \
                 >"$log_file" 2>&1
+            exit_code=$?
+            set -e
             end_time=$(date +%s)
             duration=$((end_time - start_time))
             echo "[$(date '+%F %T')] END ${assay}_${fp}_${model}" >> "$slurm_out"
+            error_msg=""
+            if [ $exit_code -ne 0 ]; then
+                error_msg=$(grep -m1 'ValueError' "$log_file" || true)
+            fi
             test_f1=$(grep -o "Test F1 Score: [0-9.e+-]*" "$log_file" | awk '{print $4}' | tail -n1)
             val_f1=$(grep -o "Validation F1 Score: [0-9.e+-]*" "$log_file" | awk '{print $4}' | tail -n1)
             test_auc=$(grep -o "Test AUC: [0-9.e+-]*" "$log_file" | awk '{print $3}' | tail -n1)
@@ -130,10 +137,20 @@ try:
     data=json.load(open(f))
 except Exception:
     data=[]
-rec={"assay_name":"$assay","MF":"$fp","Model":"$model","duration":$duration,
-     "F1":float("${test_f1:-0}"),"valF1":float("${val_f1:-0}"),
-     "AUC":float("${test_auc:-0}"),"valAUC":float("${val_auc:-0}"),
-     "Precision":float("${precision:-0}"),"Recall":float("${recall:-0}"),"Accuracy":float("${accuracy:-0}")}
+rec={"assay_name":"$assay","MF":"$fp","Model":"$model","duration":$duration}
+error="$error_msg"
+if error:
+    rec["Error"] = error
+else:
+    rec.update({
+        "F1":float("${test_f1:-0}"),
+        "valF1":float("${val_f1:-0}"),
+        "AUC":float("${test_auc:-0}"),
+        "valAUC":float("${val_auc:-0}"),
+        "Precision":float("${precision:-0}"),
+        "Recall":float("${recall:-0}"),
+        "Accuracy":float("${accuracy:-0}")
+    })
 data.append(rec)
 json.dump(data,open(f,'w'),indent=2)
 PY


### PR DESCRIPTION
## Summary
- fix assay column parsing in `run_training.sh` to start from the third column
- allow training jobs to continue after errors and capture error messages
- include captured error messages when updating `training_results_template.xlsx`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68885f963c0c83208e5ea7d077c17546