### PR TITLE
Handle flexible SMILES column

### DIFF
--- a/ToxCast_model/prediction/Predict_data.py
+++ b/ToxCast_model/prediction/Predict_data.py
@@ -55,7 +55,10 @@ if __name__ == "__main__":
     # 입력 데이터 읽기
     data = pd.read_excel(input_excel_path, sheet_name="assay_list")
     SMILES_df = pd.read_excel(SMILES_path, sheet_name="data", header=1)
-    SMILES = SMILES_df['SMILES']
+    smiles_col = next((c for c in SMILES_df.columns if c.strip().lower() == "smiles"), None)
+    if smiles_col is None:
+        raise KeyError("엑셀 파일에 'SMILES' 열이 없습니다.")
+    SMILES = SMILES_df[smiles_col]
 
     # 필요한 열 추출
     if MODEL_SELECTION == 0:

--- a/ToxCast_model/toxcast_pkg/smiles2fing.py
+++ b/ToxCast_model/toxcast_pkg/smiles2fing.py
@@ -63,10 +63,11 @@ if __name__ == "__main__":
     # 엑셀 파일 읽기 - "data" 시트가 반드시 존재해야 함
     data = pd.read_excel(input_excel_path, sheet_name="data", header=1)
 
-    # SMILES 열 추출
-    if 'SMILES' not in data.columns:
+    # SMILES 열 추출 (대소문자나 공백을 허용)
+    smiles_col = next((c for c in data.columns if c.strip().lower() == 'smiles'), None)
+    if smiles_col is None:
         raise KeyError("엑셀 파일에 'SMILES' 열이 없습니다.")
-    smiles = data['SMILES']
+    smiles = data[smiles_col]
 
     # Fingerprint 유형 리스트
     fps = ['MACCS', 'Morgan', 'RDKit', 'Layered', 'Pattern']


### PR DESCRIPTION
## Summary
- Allow SMILES column detection to be case-insensitive in fingerprint generation
- Apply same flexible lookup for prediction input

## Testing
- `python -m pytest ToxCast_model/test.py` *(fails: SyntaxError in ToxCast_model/test.py)*

------
https://chatgpt.com/codex/tasks/task_e_6899991f9e748320ac476b7aca903376