### PR TITLE
Improve class balancing and GPU usage in model scripts

### DIFF
--- a/ToxCast_model/v.2/run_v.2/dt.py
+++ b/ToxCast_model/v.2/run_v.2/dt.py
@@ -32,6 +32,20 @@ def save_results(result, path):
     with open(path, 'w') as f:
         json.dump(result, f)
 
+
+def apply_smote(x, y, random_state):
+    positive_count = np.sum(y == 1)
+    if positive_count > 1:
+        k_neighbors = min(5, positive_count - 1)
+        sm = SMOTE(random_state=random_state, k_neighbors=k_neighbors)
+        try:
+            return sm.fit_resample(x, y)
+        except ValueError as e:
+            logging.error(f"SMOTE failed: {e}")
+            return x, y
+    logging.warning("Not enough positive samples for SMOTE; skipping oversampling.")
+    return x, y
+
 def find_best_model(results, metric='f1', metric_agg='mean'):
     best_model = None
     best_score = -np.inf
@@ -103,7 +117,9 @@ def main(fingerprint_type, file_path, model_save_path, assay_num, fp_path, time_
     except ValueError:
         raise ValueError(f"Invalid time format for time_now: {time_now}. Expected format: 'HH-MM-SS'")
     
-    x_train, x_test, y_train, y_test = train_test_split(x, y, test_size=0.2, shuffle=True, random_state=random_seed) #04.04 randomstate=42 제거 #04.07 randomeseed=time_now
+    x_train, x_test, y_train, y_test = train_test_split(
+        x, y, test_size=0.2, shuffle=True, stratify=y, random_state=random_seed
+    )
     
     
     # 저장 디렉토리 설정
@@ -130,7 +146,7 @@ def main(fingerprint_type, file_path, model_save_path, assay_num, fp_path, time_
     params = ParameterGrid(params_dict)
 
     result = {'model': {}, 'precision': {}, 'recall': {}, 'f1': {}, 'accuracy': {}, 'roc_auc': {}}
-    kf = StratifiedKFold(n_splits=5, shuffle=True, random_state=42)
+    kf = StratifiedKFold(n_splits=5, shuffle=True, random_state=random_seed)
 
     # 훈련 데이터셋에서 5-fold 교차검증 수행
     for p in tqdm(range(len(params))):
@@ -146,10 +162,9 @@ def main(fingerprint_type, file_path, model_save_path, assay_num, fp_path, time_
             fold_train_x, fold_val_x = x_train.iloc[train_idx], x_train.iloc[val_idx]
             fold_train_y, fold_val_y = y_train.iloc[train_idx], y_train.iloc[val_idx]
 
-            sm = SMOTE(random_state=42)
-            fold_train_x, fold_train_y = sm.fit_resample(fold_train_x, fold_train_y)
+            fold_train_x, fold_train_y = apply_smote(fold_train_x, fold_train_y, random_seed)
 
-            model = DecisionTreeClassifier(random_state=42, **params[p])
+            model = DecisionTreeClassifier(random_state=random_seed, **params[p])
             model.fit(fold_train_x, fold_train_y)
             pred_probs = model.predict_proba(fold_val_x)[:, 1]  # 확률 예측값 사용
             pred = model.predict(fold_val_x)
@@ -179,8 +194,9 @@ def main(fingerprint_type, file_path, model_save_path, assay_num, fp_path, time_
     logging.info(f"Validation AUC: {best_roc_auc}")
 
     # 최적 모델을 전체 훈련 데이터셋에 대해 다시 학습하고 테스트 셋에서 평가
-    final_model = DecisionTreeClassifier(random_state=42, **best_model)
-    final_model.fit(x_train, y_train)
+    final_model = DecisionTreeClassifier(random_state=random_seed, **best_model)
+    x_train_res, y_train_res = apply_smote(x_train, y_train, random_seed)
+    final_model.fit(x_train_res, y_train_res)
     final_pred_probs = final_model.predict_proba(x_test)[:, 1]  # 확률 예측값 사용
     final_pred = final_model.predict(x_test)
 
@@ -215,4 +231,12 @@ if __name__ == '__main__':
     parser.add_argument('--time_now', type=str, help='Timestamp for the current run')
     parser.add_argument('--data_name', type=str, help='Data type for training')
     args = parser.parse_args()
-    main(args.fingerprint_type, args.file_path, args.model_save_path, args.assay_num, args.fp_path, args.time_now, args.data_name)
+    main(
+        args.fingerprint_type,
+        args.file_path,
+        args.model_save_path,
+        args.assay_num,
+        args.fp_path,
+        args.time_now,
+        args.data_name,
+    )

--- a/ToxCast_model/v.2/run_v.2/gbt.py
+++ b/ToxCast_model/v.2/run_v.2/gbt.py
@@ -29,6 +29,20 @@ def save_results(result, path):
     with open(path, 'w') as f:
         json.dump(result, f)
 
+
+def apply_smote(x, y, random_state):
+    positive_count = np.sum(y == 1)
+    if positive_count > 1:
+        k_neighbors = min(5, positive_count - 1)
+        sm = SMOTE(random_state=random_state, k_neighbors=k_neighbors)
+        try:
+            return sm.fit_resample(x, y)
+        except ValueError as e:
+            logging.error(f"SMOTE failed: {e}")
+            return x, y
+    logging.warning("Not enough positive samples for SMOTE; skipping oversampling.")
+    return x, y
+
 def find_best_model(results, metric='f1', metric_agg='mean'):
     best_model = None
     best_score = -np.inf
@@ -99,7 +113,9 @@ def main(fingerprint_type, file_path, model_save_path, assay_num, fp_path, time_
     except ValueError:
         raise ValueError(f"Invalid time format for time_now: {time_now}. Expected format: 'HH-MM-SS'")
     
-    x_train, x_test, y_train, y_test = train_test_split(x, y, test_size=0.2, shuffle=True, random_state=random_seed) #04.07 randomstate=42 제거
+    x_train, x_test, y_train, y_test = train_test_split(
+        x, y, test_size=0.2, shuffle=True, stratify=y, random_state=random_seed
+    )
     
 
     # 저장 디렉토리 설정
@@ -125,7 +141,7 @@ def main(fingerprint_type, file_path, model_save_path, assay_num, fp_path, time_
     params = ParameterGrid(params_dict)
 
     result = {'model': {}, 'precision': {}, 'recall': {}, 'f1': {}, 'accuracy': {}, 'roc_auc': {}}
-    kf = StratifiedKFold(n_splits=5, shuffle=True, random_state=42)
+    kf = StratifiedKFold(n_splits=5, shuffle=True, random_state=random_seed)
 
     # 훈련 데이터셋에서 5-fold 교차검증 수행
     for p in tqdm(range(len(params))):
@@ -141,10 +157,9 @@ def main(fingerprint_type, file_path, model_save_path, assay_num, fp_path, time_
             fold_train_x, fold_val_x = x_train.iloc[train_idx], x_train.iloc[val_idx]
             fold_train_y, fold_val_y = y_train.iloc[train_idx], y_train.iloc[val_idx]
 
-            sm = SMOTE(random_state=42)
-            fold_train_x, fold_train_y = sm.fit_resample(fold_train_x, fold_train_y)
+            fold_train_x, fold_train_y = apply_smote(fold_train_x, fold_train_y, random_seed)
 
-            model = GradientBoostingClassifier(random_state=42, **params[p])
+            model = GradientBoostingClassifier(random_state=random_seed, **params[p])
             model.fit(fold_train_x, fold_train_y)
             pred_probs = model.predict_proba(fold_val_x)[:, 1]  # 확률 예측값 사용
             pred = model.predict(fold_val_x)
@@ -174,8 +189,9 @@ def main(fingerprint_type, file_path, model_save_path, assay_num, fp_path, time_
     logging.info(f"Validation AUC: {best_roc_auc}")
 
     # 최적 모델을 전체 훈련 데이터셋에 대해 다시 학습하고 테스트 셋에서 평가
-    final_model = GradientBoostingClassifier(random_state=42, **best_model)
-    final_model.fit(x_train, y_train)
+    final_model = GradientBoostingClassifier(random_state=random_seed, **best_model)
+    x_train_res, y_train_res = apply_smote(x_train, y_train, random_seed)
+    final_model.fit(x_train_res, y_train_res)
     final_pred_probs = final_model.predict_proba(x_test)[:, 1]  # 확률 예측값 사용
     final_pred = final_model.predict(x_test)
 
@@ -209,5 +225,13 @@ if __name__ == '__main__':
     parser.add_argument('--time_now', type=str, help='Timestamp for the current run')
     parser.add_argument('--data_name', type=str, help='Data type for training')
     args = parser.parse_args()
-    main(args.fingerprint_type, args.file_path, args.model_save_path, args.assay_num, args.fp_path, args.time_now, args.data_name)
+    main(
+        args.fingerprint_type,
+        args.file_path,
+        args.model_save_path,
+        args.assay_num,
+        args.fp_path,
+        args.time_now,
+        args.data_name,
+    )
     

--- a/ToxCast_model/v.2/run_v.2/logistic.py
+++ b/ToxCast_model/v.2/run_v.2/logistic.py
@@ -29,6 +29,20 @@ def save_results(result, path):
     with open(path, 'w') as f:
         json.dump(result, f)
 
+
+def apply_smote(x, y, random_state):
+    positive_count = np.sum(y == 1)
+    if positive_count > 1:
+        k_neighbors = min(5, positive_count - 1)
+        sm = SMOTE(random_state=random_state, k_neighbors=k_neighbors)
+        try:
+            return sm.fit_resample(x, y)
+        except ValueError as e:
+            logging.error(f"SMOTE failed: {e}")
+            return x, y
+    logging.warning("Not enough positive samples for SMOTE; skipping oversampling.")
+    return x, y
+
 def find_best_model(results, metric='f1', metric_agg='mean'):
     best_model = None
     best_score = -np.inf
@@ -100,7 +114,9 @@ def main(fingerprint_type, file_path, model_save_path, assay_num, fp_path, time_
     except ValueError:
         raise ValueError(f"Invalid time format for time_now: {time_now}. Expected format: 'HH-MM-SS'")
     
-    x_train, x_test, y_train, y_test = train_test_split(x, y, test_size=0.2, shuffle=True, random_state=random_seed) #04.07 randomstate=42 제거
+    x_train, x_test, y_train, y_test = train_test_split(
+        x, y, test_size=0.2, shuffle=True, stratify=y, random_state=random_seed
+    )
     
     
     # 저장 디렉토리 설정
@@ -128,7 +144,7 @@ def main(fingerprint_type, file_path, model_save_path, assay_num, fp_path, time_
     params = ParameterGrid(params_dict)
 
     result = {'model': {}, 'precision': {}, 'recall': {}, 'f1': {}, 'accuracy': {}, 'roc_auc': {}}
-    kf = StratifiedKFold(n_splits=5, shuffle=True, random_state=42)
+    kf = StratifiedKFold(n_splits=5, shuffle=True, random_state=random_seed)
 
     # 훈련 데이터셋에서 5-fold 교차검증 수행
     for p in tqdm(range(len(params))):
@@ -144,10 +160,9 @@ def main(fingerprint_type, file_path, model_save_path, assay_num, fp_path, time_
             fold_train_x, fold_val_x = x_train.iloc[train_idx], x_train.iloc[val_idx]
             fold_train_y, fold_val_y = y_train.iloc[train_idx], y_train.iloc[val_idx]
 
-            sm = SMOTE(random_state=42)
-            fold_train_x, fold_train_y = sm.fit_resample(fold_train_x, fold_train_y)
+            fold_train_x, fold_train_y = apply_smote(fold_train_x, fold_train_y, random_seed)
 
-            model = LogisticRegression(random_state=42, **params[p])
+            model = LogisticRegression(random_state=random_seed, **params[p])
             model.fit(fold_train_x, fold_train_y)
             pred_probs = model.predict_proba(fold_val_x)[:, 1]  # 확률 예측값 사용
             pred = model.predict(fold_val_x)
@@ -177,8 +192,9 @@ def main(fingerprint_type, file_path, model_save_path, assay_num, fp_path, time_
     logging.info(f"Validation AUC: {best_roc_auc}")
 
     # 테스트 데이터에 대해 최적 모델 평가
-    final_model = LogisticRegression(random_state=42, **best_model)
-    final_model.fit(x_train, y_train)
+    final_model = LogisticRegression(random_state=random_seed, **best_model)
+    x_train_res, y_train_res = apply_smote(x_train, y_train, random_seed)
+    final_model.fit(x_train_res, y_train_res)
     final_pred_probs = final_model.predict_proba(x_test)[:, 1]  # 확률 예측값 사용
     final_pred = final_model.predict(x_test)
 
@@ -212,5 +228,13 @@ if __name__ == '__main__':
     parser.add_argument('--time_now', type=str, help='Timestamp for the current run')
     parser.add_argument('--data_name', type=str, help='Data type for training')
     args = parser.parse_args()
-    main(args.fingerprint_type, args.file_path, args.model_save_path, args.assay_num, args.fp_path, args.time_now, args.data_name)
+    main(
+        args.fingerprint_type,
+        args.file_path,
+        args.model_save_path,
+        args.assay_num,
+        args.fp_path,
+        args.time_now,
+        args.data_name,
+    )
 

--- a/ToxCast_model/v.2/run_v.2/rf.py
+++ b/ToxCast_model/v.2/run_v.2/rf.py
@@ -29,6 +29,20 @@ def save_results(result, path):
     with open(path, 'w') as f:
         json.dump(result, f)
 
+
+def apply_smote(x, y, random_state):
+    positive_count = np.sum(y == 1)
+    if positive_count > 1:
+        k_neighbors = min(5, positive_count - 1)
+        sm = SMOTE(random_state=random_state, k_neighbors=k_neighbors)
+        try:
+            return sm.fit_resample(x, y)
+        except ValueError as e:
+            logging.error(f"SMOTE failed: {e}")
+            return x, y
+    logging.warning("Not enough positive samples for SMOTE; skipping oversampling.")
+    return x, y
+
 def find_best_model(results, metric='f1', metric_agg='mean'):
     best_model = None
     best_score = -np.inf
@@ -100,7 +114,9 @@ def main(fingerprint_type, file_path, model_save_path, assay_num, fp_path, time_
     except ValueError:
         raise ValueError(f"Invalid time format for time_now: {time_now}. Expected format: 'HH-MM-SS'")
     
-    x_train, x_test, y_train, y_test = train_test_split(x, y, test_size=0.2, shuffle=True, random_state=random_seed) #04.07 randomstate=42 제거
+    x_train, x_test, y_train, y_test = train_test_split(
+        x, y, test_size=0.2, shuffle=True, stratify=y, random_state=random_seed
+    )
     
     
     # 저장 디렉토리 설정
@@ -129,7 +145,7 @@ def main(fingerprint_type, file_path, model_save_path, assay_num, fp_path, time_
     params = ParameterGrid(params_dict)
 
     result = {'model': {}, 'precision': {}, 'recall': {}, 'f1': {}, 'accuracy': {}, 'roc_auc': {}}
-    kf = StratifiedKFold(n_splits=5, shuffle=True, random_state=42)
+    kf = StratifiedKFold(n_splits=5, shuffle=True, random_state=random_seed)
 
     # 훈련 데이터셋에서 5-fold 교차검증 수행
     for p in tqdm(range(len(params))):
@@ -145,10 +161,9 @@ def main(fingerprint_type, file_path, model_save_path, assay_num, fp_path, time_
             fold_train_x, fold_val_x = x_train.iloc[train_idx], x_train.iloc[val_idx]
             fold_train_y, fold_val_y = y_train.iloc[train_idx], y_train.iloc[val_idx]
 
-            sm = SMOTE(random_state=42)
-            fold_train_x, fold_train_y = sm.fit_resample(fold_train_x, fold_train_y)
+            fold_train_x, fold_train_y = apply_smote(fold_train_x, fold_train_y, random_seed)
 
-            model = RandomForestClassifier(random_state=42, **params[p])
+            model = RandomForestClassifier(random_state=random_seed, **params[p])
             model.fit(fold_train_x, fold_train_y)
             pred_probs = model.predict_proba(fold_val_x)[:, 1]  # 확률 예측값 사용
             pred = model.predict(fold_val_x)
@@ -178,8 +193,9 @@ def main(fingerprint_type, file_path, model_save_path, assay_num, fp_path, time_
     logging.info(f"Validation AUC: {best_roc_auc}")
 
     # 테스트 데이터에 대해 최적 모델 평가
-    final_model = RandomForestClassifier(random_state=42, **best_model)
-    final_model.fit(x_train, y_train)
+    final_model = RandomForestClassifier(random_state=random_seed, **best_model)
+    x_train_res, y_train_res = apply_smote(x_train, y_train, random_seed)
+    final_model.fit(x_train_res, y_train_res)
     final_pred_probs = final_model.predict_proba(x_test)[:, 1]  # 확률 예측값 사용
     final_pred = final_model.predict(x_test)
 
@@ -213,4 +229,13 @@ if __name__ == '__main__':
     parser.add_argument('--time_now', type=str, help='Timestamp for the current run')
     parser.add_argument('--data_name', type=str, help='Data type for training')
     args = parser.parse_args()
-    main(args.fingerprint_type, args.file_path, args.model_save_path, args.assay_num, args.fp_path, args.time_now, args.data_name)
+    main(
+        args.fingerprint_type,
+        args.file_path,
+        args.model_save_path,
+        args.assay_num,
+        args.fp_path,
+        args.time_now,
+        args.data_name,
+    )
+

--- a/ToxCast_model/v.2/run_v.2/xgb.py
+++ b/ToxCast_model/v.2/run_v.2/xgb.py
@@ -36,6 +36,42 @@ def save_results(result, path):
     with open(path, 'w') as f:
         json.dump(result, f)
 
+
+def find_best_model(results, metric='f1', metric_agg='mean'):
+    best_model = None
+    best_score = -np.inf
+    best_model_key = None
+
+    for model_key in results['model'].keys():
+        scores = results[metric][model_key]
+        if metric_agg == 'mean':
+            agg_score = np.mean(scores)
+        elif metric_agg == 'median':
+            agg_score = np.median(scores)
+        else:
+            raise ValueError("metric_agg must be either 'mean' or 'median'")
+
+        if agg_score > best_score:
+            best_score = agg_score
+            best_model = results['model'][model_key]
+            best_model_key = model_key
+
+    return best_model_key, best_model, best_score
+
+
+def apply_smote(x, y, random_state):
+    positive_count = np.sum(y == 1)
+    if positive_count > 1:
+        k_neighbors = min(5, positive_count - 1)
+        sm = SMOTE(random_state=random_state, k_neighbors=k_neighbors)
+        try:
+            return sm.fit_resample(x, y)
+        except ValueError as e:
+            logging.error(f"SMOTE failed: {e}")
+            return x, y
+    logging.warning("Not enough positive samples for SMOTE; skipping oversampling.")
+    return x, y
+
 def main(fingerprint_type, file_path, model_save_path, assay_num, fp_path, time_now, data_name):
 
     if fingerprint_type == 'MACCS':
@@ -86,7 +122,9 @@ def main(fingerprint_type, file_path, model_save_path, assay_num, fp_path, time_
     except ValueError:
         raise ValueError(f"Invalid time format for time_now: {time_now}. Expected format: 'HH-MM-SS'")
     
-    x_train, x_test, y_train, y_test = train_test_split(x, y, test_size=0.2, shuffle=True, random_state=random_seed) #04.07 randomstate=42 제거
+    x_train, x_test, y_train, y_test = train_test_split(
+        x, y, test_size=0.2, shuffle=True, stratify=y, random_state=random_seed
+    )
     
     
     # 저장 디렉토리 설정
@@ -115,7 +153,7 @@ def main(fingerprint_type, file_path, model_save_path, assay_num, fp_path, time_
     params = ParameterGrid(params_dict)
 
     result = {'model': {}, 'precision': {}, 'recall': {}, 'f1': {}, 'accuracy': {}, 'roc_auc': {}}
-    kf = StratifiedKFold(n_splits=5, shuffle=True, random_state=42)
+    kf = StratifiedKFold(n_splits=5, shuffle=True, random_state=random_seed)
 
     # 훈련 데이터셋에서 5-fold 교차검증 수행
     for p in tqdm(range(len(params))):
@@ -131,10 +169,18 @@ def main(fingerprint_type, file_path, model_save_path, assay_num, fp_path, time_
             fold_train_x, fold_val_x = x_train.iloc[train_idx], x_train.iloc[val_idx]
             fold_train_y, fold_val_y = y_train.iloc[train_idx], y_train.iloc[val_idx]
 
-            sm = SMOTE(random_state=42)
-            fold_train_x, fold_train_y = sm.fit_resample(fold_train_x, fold_train_y)
+            fold_train_x, fold_train_y = apply_smote(fold_train_x, fold_train_y, random_seed)
 
-            model = XGBClassifier(random_state=42, **params[p])
+            gpu_params = {
+                'tree_method': 'gpu_hist',
+                'predictor': 'gpu_predictor',
+                'gpu_id': 0
+            }
+            try:
+                model = XGBClassifier(random_state=random_seed, **gpu_params, **params[p])
+            except Exception as e:
+                logging.warning(f"GPU not available, fallback to CPU: {e}")
+                model = XGBClassifier(random_state=random_seed, **params[p])
             model.fit(fold_train_x, fold_train_y)
             pred_probs = model.predict_proba(fold_val_x)[:, 1]  # 확률 예측값 사용
             pred = model.predict(fold_val_x)
@@ -164,8 +210,19 @@ def main(fingerprint_type, file_path, model_save_path, assay_num, fp_path, time_
     logging.info(f"Validation AUC: {best_roc_auc}")
 
     # 테스트 데이터에 대해 최적 모델 평가
-    final_model = XGBClassifier(random_state=42, **best_model)
-    final_model.fit(x_train, y_train)
+    gpu_params = {
+        'tree_method': 'gpu_hist',
+        'predictor': 'gpu_predictor',
+        'gpu_id': 0
+    }
+    try:
+        final_model = XGBClassifier(random_state=random_seed, **gpu_params, **best_model)
+    except Exception as e:
+        logging.warning(f"GPU not available, fallback to CPU: {e}")
+        final_model = XGBClassifier(random_state=random_seed, **best_model)
+
+    x_train_res, y_train_res = apply_smote(x_train, y_train, random_seed)
+    final_model.fit(x_train_res, y_train_res)
     final_pred_probs = final_model.predict_proba(x_test)[:, 1]  # 확률 예측값 사용
     final_pred = final_model.predict(x_test)
 
@@ -199,5 +256,14 @@ if __name__ == '__main__':
     parser.add_argument('--time_now', type=str, help='Timestamp for the current run')
     parser.add_argument('--data_name', type=str, help='Data type for training')
     args = parser.parse_args()
-    main(args.fingerprint_type, args.file_path, args.model_save_path, args.assay_num, args.fp_path, args.time_now, args.data_name)
+    main(
+        args.fingerprint_type,
+        args.file_path,
+        args.model_save_path,
+        args.assay_num,
+        args.fp_path,
+        args.time_now,
+        args.data_name,
+    )
+
 


### PR DESCRIPTION
## Summary
- Add adaptive SMOTE helper to handle scarce positive samples and apply during CV and final training
- Preserve class ratios by stratifying train/test splits across all run_v.2 models
- Accelerate XGBoost with optional GPU parameters and CPU fallback

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a7f10ad5b48320bcf6c7d5b075685a