### PR TITLE
Enable GPU modules and model version selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ This repository contains utilities for training and predicting toxicological act
 - Centralised configuration via `ToxCast_model/config.py`
 - Single entry script `run_pipeline.sh` to generate fingerprints, train models and run predictions
 - Prediction runs save results in timestamped folders and write a `metadata.json` summary in `experiments/<PROJECT_NAME>/results/`
+- Configurable model version via `VERSION` in `config.py`
+- Fingerprint generation skips automatically if files already exist
 
 
 ## Project layout
@@ -28,13 +30,19 @@ ToxCast_model/              # Main source code
 2. Copy `Template/template_for_predict(PROJECT_NAME)` into `ToxCast_model/experiments/` and rename the folder to your project name.
 3. Place the Excel file from step&nbsp;1 inside this new folder.
 4. Edit `ToxCast_model/config.py` and set `PROJECT_NAME` to the folder name from step&nbsp;2.
-5. Set `OBJECT = 0` in `config.py` for prediction mode.
-6. Set `MODEL_SELECTION = 0` in `config.py` for best F1 mode
-7. Run the pipeline from the project root:
+5. Optionally set `VERSION = 2` in `config.py` to use the `ToxCast_model_v.2`
+   models (default is 1).
+6. Set `OBJECT = 0` in `config.py` for prediction mode.
+7. Set `MODEL_SELECTION = 0` in `config.py` for best F1 mode
+8. Run the pipeline from the project root:
 
 ```bash
 bash launcher.sh
 ```
+
+The launcher and Slurm scripts automatically load the `cuda/12.2.1` and
+`python/3.11.2` modules to enable GPU execution. Adjust the module names if your
+environment differs.
 
 ### Local usage
 

--- a/ToxCast_model/config.py
+++ b/ToxCast_model/config.py
@@ -14,6 +14,10 @@ OBJECT = 0
 # 1 -> user-specified model and fingerprint
 MODEL_SELECTION_OPTIONS = ["best_f1", "model+mf"]
 MODEL_SELECTION = 1
+# model version
+# 1 -> original ToxCast_model
+# 2 -> ToxCast_model_v.2
+VERSION = 1
 # ----- Basic experiment info -----
 # Only change PROJECT_NAME for each run. The experiment directory must exist
 # under ``experiments/`` and contain exactly one Excel file with the training and

--- a/launcher.sh
+++ b/launcher.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 # Unified launcher for training or prediction
 
+# Load required modules for GPU execution
+module purge
+module load cuda/12.2.1
+module load python/3.11.2
+
 script_dir="$(cd "$(dirname "$0")" && pwd)"
 mode=$(python - <<'PY'
 import config

--- a/slurm/run_prediction.sh
+++ b/slurm/run_prediction.sh
@@ -1,9 +1,32 @@
 #!/bin/bash
 # Run fingerprint generation and either training or prediction based on config.py
 
+# Load required modules for GPU execution
+module purge
+module load cuda/12.2.1
+module load python/3.11.2
+
 # resolve script directory and determine action
 script_dir="$(cd "$(dirname "$0")" && pwd)"
-model_dir="$(cd "$script_dir/../ToxCast_model" && pwd)"
+
+# Determine model directory based on config.VERSION
+version=$(python - "$script_dir" <<'PY'
+import sys, pathlib
+script_dir = pathlib.Path(sys.argv[1])
+sys.path.append(str(script_dir.parent / "ToxCast_model"))
+import config
+print(getattr(config, "VERSION", 1))
+PY
+)
+if [ "$version" = "2" ]; then
+    model_dir="$(cd "$script_dir/../ToxCast_model/ToxCast_model_v.2" && pwd)"
+    training_script="ToxCast_model_training_v.2.sh"
+    prediction_script="prediction_v.2/Predict_data_v.2.py"
+else
+    model_dir="$(cd "$script_dir/../ToxCast_model" && pwd)"
+    training_script="ToxCast_model_training.sh"
+    prediction_script="prediction/Predict_data.py"
+fi
 
 if [ -n "$SLURM_LAUNCHED" ]; then
     run_doa() { bash prediction/run_doa_slurm.sh "$1" "$2"; }
@@ -52,8 +75,15 @@ import config
 config.validate_paths()
 PY
 
-# generate fingerprints
-python -m toxcast_pkg.smiles2fing
+# generate fingerprints only if not already present
+fp_dir=$(python - <<'PY'
+import config
+print(config.FINGERPRINT_OUTPUT_DIR)
+PY
+)
+if [ -z "$(ls -A "$fp_dir" 2>/dev/null)" ]; then
+    python -m toxcast_pkg.smiles2fing
+fi
 
 # determine mode from config
 mode=$(python - <<'PY'
@@ -66,19 +96,23 @@ echo "Running mode: $mode"
 
 case "$mode" in
     training)
-        bash ToxCast_model_training.sh
+        bash "$training_script"
         ;;
     prediction)
-        PYTHONPATH=. python prediction/Predict_data.py --skip-doa
-        results_dir=$(python - <<'PY'
+        if [ "$version" = "2" ]; then
+            PYTHONPATH=. python "$prediction_script"
+        else
+            PYTHONPATH=. python "$prediction_script" --skip-doa
+            results_dir=$(python - <<'PY'
 import config
 print(config.RESULTS_DIR)
 PY
 )
-        latest_dir=$(ls -dt "$results_dir"/*/ | head -n1)  
-        result_file=$(ls "$latest_dir"/*_prediction.xlsx | head -n1)
-        metadata_file="$results_dir/metadata.json"
-        run_doa "$result_file" "$metadata_file"
+            latest_dir=$(ls -dt "$results_dir"/*/ | head -n1)
+            result_file=$(ls "$latest_dir"/*_prediction.xlsx | head -n1)
+            metadata_file="$results_dir/metadata.json"
+            run_doa "$result_file" "$metadata_file"
+        fi
         ;;
     *)
         echo "Unknown mode: $mode"

--- a/slurm/run_training.sh
+++ b/slurm/run_training.sh
@@ -2,8 +2,29 @@
 # Convenience script to train models for a project directory
 set -e
 
+# Load required modules for GPU execution
+module purge
+module load cuda/12.2.1
+module load python/3.11.2
+
 script_dir="$(cd "$(dirname "$0")" && pwd)"
-model_dir="$(cd "$script_dir/../ToxCast_model" && pwd)"
+
+# Determine model directory based on config.VERSION
+version=$(python - "$script_dir" <<'PY'
+import sys, pathlib
+script_dir = pathlib.Path(sys.argv[1])
+sys.path.append(str(script_dir.parent / "ToxCast_model"))
+import config
+print(getattr(config, "VERSION", 1))
+PY
+)
+if [ "$version" = "2" ]; then
+    model_dir="$(cd "$script_dir/../ToxCast_model/ToxCast_model_v.2" && pwd)"
+    run_subdir="run_v.2"
+else
+    model_dir="$(cd "$script_dir/../ToxCast_model" && pwd)"
+    run_subdir="run"
+fi
 
 current_date=$(date +%Y-%m-%d)
 current_time=$(date +%H-%M-%S)
@@ -69,6 +90,11 @@ metadata_file="$project_dir/metadata.json"
 mkdir -p "$results_dir" "$logs_dir" "$fp_dir"
 : > "$metadata_file"
 
+# Generate fingerprints only if they do not already exist
+if [ -z "$(ls -A "$fp_dir" 2>/dev/null)" ]; then
+    PYTHONPATH="$model_dir" python -m toxcast_pkg.smiles2fing
+fi
+
 mapfile -t assays < <(python - "$input_excel" <<'PY'
 import sys, zipfile, xml.etree.ElementTree as ET
 xlsx=sys.argv[1]
@@ -107,7 +133,7 @@ for assay in "${assays[@]}"; do
             echo "[$(date '+%F %T')] START ${assay}_${fp}_${model}" >> "$slurm_out"
             start_time=$(date +%s)
             set +e
-            PYTHONPATH="$model_dir" python "$model_dir/run/${model}.py" \
+            PYTHONPATH="$model_dir" python "$model_dir/$run_subdir/${model}.py" \
                 --fingerprint_type "$fp" \
                 --file_path "$input_excel" \
                 --model_save_path "$save_dir" \


### PR DESCRIPTION
## Summary
- Allow selecting between original and v2 models via new `VERSION` in `config.py`.
- Load CUDA and Python modules in launcher and Slurm scripts for GPU jobs.
- Skip fingerprint generation when existing outputs are present.

## Testing
- `python -m py_compile ToxCast_model/config.py`
- `bash -n launcher.sh slurm/run_training.sh slurm/run_prediction.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a7f618c9988320b7fc64350f89b7ae