### PR TITLE
Make experiment outputs version-agnostic

### DIFF
--- a/ToxCast_model/config.py
+++ b/ToxCast_model/config.py
@@ -28,7 +28,11 @@ PROJECT_NAME = "KGML"
 
 
 # ----- Derived paths based on the directory layout -----
-BASE_DIR = Path("experiments") / OBJECTS[OBJECT] / PROJECT_NAME
+# Resolve paths relative to this file so experiments live in the top-level
+# ``ToxCast_model/experiments`` regardless of the selected VERSION or the
+# current working directory.
+ROOT_DIR = Path(__file__).resolve().parent
+BASE_DIR = ROOT_DIR / "experiments" / OBJECTS[OBJECT] / PROJECT_NAME
 
 FINGERPRINT_DIR = BASE_DIR / "fingerprints"
 FINGERPRINT_OUTPUT_DIR = FINGERPRINT_DIR

--- a/slurm/run_prediction.sh
+++ b/slurm/run_prediction.sh
@@ -15,21 +15,21 @@ else
     script_dir="$(cd "$(dirname "$0")" && pwd)"
 fi
 
+# Base directory containing shared config and experiments
+base_model_dir="$(cd "$script_dir/../ToxCast_model" && pwd)"
+
 # Determine model directory based on config.VERSION
-version=$(python - "$script_dir" <<'PY'
-import sys, pathlib
-script_dir = pathlib.Path(sys.argv[1])
-sys.path.append(str(script_dir.parent / "ToxCast_model"))
+version=$(PYTHONPATH="$base_model_dir" python - <<'PY'
 import config
 print(getattr(config, "VERSION", 1))
 PY
 )
 if [ "$version" = "2" ]; then
-    model_dir="$(cd "$script_dir/../ToxCast_model/ToxCast_model_v.2" && pwd)"
+    model_dir="$base_model_dir/ToxCast_model_v.2"
     training_script="ToxCast_model_training_v.2.sh"
     prediction_script="prediction_v.2/Predict_data_v.2.py"
 else
-    model_dir="$(cd "$script_dir/../ToxCast_model" && pwd)"
+    model_dir="$base_model_dir"
     training_script="ToxCast_model_training.sh"
     prediction_script="prediction/Predict_data.py"
 fi
@@ -37,17 +37,16 @@ fi
 if [ -n "$SLURM_LAUNCHED" ]; then
     run_doa() { bash prediction/run_doa_slurm.sh "$1" "$2"; }
 else
-    run_doa() { PYTHONPATH=. python prediction/calc_doa.py "$1" --metadata-file "$2"; }
+    run_doa() { PYTHONPATH=".:$base_model_dir" python prediction/calc_doa.py "$1" --metadata-file "$2"; }
 fi
 
-project_dir=$(MODEL_DIR="$model_dir" PYTHONPATH="$model_dir" python - <<'PY'
-import os, config
-from pathlib import Path
-print(Path(os.environ['MODEL_DIR']) / config.BASE_DIR)
+project_dir=$(PYTHONPATH="$base_model_dir" python - <<'PY'
+import config
+print(config.BASE_DIR)
 PY
 )
 project_name="$(basename "$project_dir")"
-mode=$(PYTHONPATH="$model_dir" python - <<'PY'
+mode=$(PYTHONPATH="$base_model_dir" python - <<'PY'
 import config
 print(config.OBJECTS[config.OBJECT])
 PY
@@ -76,7 +75,7 @@ if [ "$step" = "doa" ]; then
     result_file="$2"
     metadata_file="$3"
     if [ -z "$result_file" ]; then
-        results_dir=$(python - <<'PY'
+        results_dir=$(PYTHONPATH="$base_model_dir" python - <<'PY'
 import config
 print(config.RESULTS_DIR)
 PY
@@ -91,26 +90,26 @@ fi
 
 if [ "$step" = "train_doa" ]; then
     cd "$model_dir" || exit 1
-    PYTHONPATH=. python prediction/calc_train_doa.py "$2"
+    PYTHONPATH=".:$base_model_dir" python prediction/calc_train_doa.py "$2"
     exit $?
 fi
 
 cd "$model_dir" || exit 1
 
 # validate experiment setup
-python - <<'PY'
+PYTHONPATH="$base_model_dir" python - <<'PY'
 import config
 config.validate_paths()
 PY
 
 # generate fingerprints only if not already present
-fp_dir=$(python - <<'PY'
+fp_dir=$(PYTHONPATH="$base_model_dir" python - <<'PY'
 import config
 print(config.FINGERPRINT_OUTPUT_DIR)
 PY
 )
 if [ -z "$(ls -A "$fp_dir" 2>/dev/null)" ]; then
-    python -m toxcast_pkg.smiles2fing
+    PYTHONPATH="$model_dir:$base_model_dir" python -m toxcast_pkg.smiles2fing
 fi
 
 # mode already determined earlier
@@ -122,10 +121,10 @@ case "$mode" in
         ;;
     prediction)
         if [ "$version" = "2" ]; then
-            PYTHONPATH=. python "$prediction_script"
+            PYTHONPATH=".:$base_model_dir" python "$prediction_script"
         else
-            PYTHONPATH=. python "$prediction_script" --skip-doa
-            results_dir=$(python - <<'PY'
+            PYTHONPATH=".:$base_model_dir" python "$prediction_script" --skip-doa
+            results_dir=$(PYTHONPATH="$base_model_dir" python - <<'PY'
 import config
 print(config.RESULTS_DIR)
 PY

--- a/slurm/run_training.sh
+++ b/slurm/run_training.sh
@@ -15,28 +15,27 @@ else
     script_dir="$(cd "$(dirname "$0")" && pwd)"
 fi
 
+# Base directory containing shared config and experiment folders
+base_model_dir="$(cd "$script_dir/../ToxCast_model" && pwd)"
+
 # Determine model directory based on config.VERSION
-version=$(python - "$script_dir" <<'PY'
-import sys, pathlib
-script_dir = pathlib.Path(sys.argv[1])
-sys.path.append(str(script_dir.parent / "ToxCast_model"))
+version=$(PYTHONPATH="$base_model_dir" python - <<'PY'
 import config
 print(getattr(config, "VERSION", 1))
 PY
 )
 if [ "$version" = "2" ]; then
-    model_dir="$(cd "$script_dir/../ToxCast_model/ToxCast_model_v.2" && pwd)"
+    model_dir="$base_model_dir/ToxCast_model_v.2"
     run_subdir="run_v.2"
 else
-    model_dir="$(cd "$script_dir/../ToxCast_model" && pwd)"
+    model_dir="$base_model_dir"
     run_subdir="run"
 fi
 
 # Determine default project directory and log location
-default_project_dir=$(MODEL_DIR="$model_dir" PYTHONPATH="$model_dir" python - <<'PY'
-import os, config
-from pathlib import Path
-print(Path(os.environ['MODEL_DIR']) / config.BASE_DIR)
+default_project_dir=$(PYTHONPATH="$base_model_dir" python - <<'PY'
+import config
+print(config.BASE_DIR)
 PY
 )
 project_dir="${1:-$default_project_dir}"
@@ -94,7 +93,7 @@ mkdir -p "$results_dir" "$logs_dir" "$fp_dir"
 
 # Generate fingerprints only if they do not already exist
 if [ -z "$(ls -A "$fp_dir" 2>/dev/null)" ]; then
-    PYTHONPATH="$model_dir" python -m toxcast_pkg.smiles2fing
+    PYTHONPATH="$model_dir:$base_model_dir" python -m toxcast_pkg.smiles2fing
 fi
 
 mapfile -t assays < <(python - "$input_excel" <<'PY'
@@ -135,7 +134,7 @@ for assay in "${assays[@]}"; do
             echo "[$(date '+%F %T')] START ${assay}_${fp}_${model}" >> "$slurm_out"
             start_time=$(date +%s)
             set +e
-            PYTHONPATH="$model_dir" python "$model_dir/$run_subdir/${model}.py" \
+            PYTHONPATH="$model_dir:$base_model_dir" python "$model_dir/$run_subdir/${model}.py" \
                 --fingerprint_type "$fp" \
                 --file_path "$input_excel" \
                 --model_save_path "$save_dir" \
@@ -187,5 +186,5 @@ PY
     assay_index=$((assay_index+1))
 done
 
-python "$model_dir/update_training_results.py" "$project_dir" "$input_excel" "$metadata_file"
+PYTHONPATH="$model_dir:$base_model_dir" python "$model_dir/update_training_results.py" "$project_dir" "$input_excel" "$metadata_file"
 echo "[$(date '+%F %T')] Training complete" >> "$slurm_out"


### PR DESCRIPTION
## Summary
- ensure `config.py` always resolves experiments under `ToxCast_model/experiments`
- update Slurm training and prediction wrappers to derive project directories from the shared config
- include base model path in `PYTHONPATH` so config can be imported regardless of model version

## Testing
- `python -m py_compile ToxCast_model/config.py`
- `bash -n slurm/run_training.sh`
- `bash -n slurm/run_prediction.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a8074a55588320b54badc5c8b922ea