### PR TITLE
Add metadata export for train/test splits

### DIFF
--- a/ToxCast_model/ToxCast_model_v.2/run_v.2/dt.py
+++ b/ToxCast_model/ToxCast_model_v.2/run_v.2/dt.py
@@ -14,9 +14,9 @@ import joblib
 import logging
 import numpy as np
 from tqdm import tqdm
-from sklearn.model_selection import StratifiedKFold, train_test_split
+from sklearn.model_selection import StratifiedKFold
 from sklearn.metrics import precision_score, recall_score, accuracy_score, f1_score, roc_auc_score
-from toxcast_pkg.common import ParameterGrid
+from toxcast_pkg.common import ParameterGrid, split_train_test_with_metadata
 from rdkit import RDLogger
 from imblearn.over_sampling import SMOTE
 from sklearn.tree import DecisionTreeClassifier
@@ -98,16 +98,16 @@ def main(fingerprint_type, file_path, model_save_path, assay_num, fp_path, time_
     df = pd.read_excel(file_path, header=1)
     assay_name = df.columns[assay_num+1]
     if drop_idx:
-        y = df.iloc[:, assay_num+1].drop(drop_idx).reset_index(drop=True)
+        base_df = df.drop(index=drop_idx).reset_index(drop=True)
     else:
-        y = df.iloc[:, assay_num+1].reset_index(drop=True)
+        base_df = df.reset_index(drop=True)
+    y = base_df.iloc[:, assay_num+1]
 
     na_idx = y[y.isnull()].index
     y = y.drop(index=na_idx).reset_index(drop=True)
     x = x.drop(index=na_idx).reset_index(drop=True)
+    base_df = base_df.drop(index=na_idx).reset_index(drop=True)
 
-############################################################################04.04 위 수정 x
-    
     date_today = datetime.today().strftime("%Y%m%d")
 
     # time_now를 datetime 객체로 변환
@@ -116,12 +116,12 @@ def main(fingerprint_type, file_path, model_save_path, assay_num, fp_path, time_
         random_seed = abs(int(time_now_obj.timestamp()))
     except ValueError:
         raise ValueError(f"Invalid time format for time_now: {time_now}. Expected format: 'HH-MM-SS'")
-    
-    x_train, x_test, y_train, y_test = train_test_split(
-        x, y, test_size=0.2, shuffle=True, stratify=y, random_state=random_seed
+
+    x_train, x_test, y_train, y_test = split_train_test_with_metadata(
+        x, y, base_df, file_path, assay_name,
+        random_state=random_seed, stratify=y
     )
-    
-    
+
     # 저장 디렉토리 설정
     save_dir = f'./data_v.2/train_test_split/{data_name}/{assay_name}/{fingerprint_type}_dt/{date_today}/{time_now}'
     os.makedirs(save_dir, exist_ok=True)

--- a/ToxCast_model/ToxCast_model_v.2/run_v.2/gbt.py
+++ b/ToxCast_model/ToxCast_model_v.2/run_v.2/gbt.py
@@ -9,9 +9,9 @@ import warnings
 import joblib
 import logging
 from tqdm import tqdm
-from sklearn.model_selection import StratifiedKFold, train_test_split
+from sklearn.model_selection import StratifiedKFold
 from sklearn.metrics import precision_score, recall_score, accuracy_score, f1_score, roc_auc_score
-from toxcast_pkg.common import ParameterGrid
+from toxcast_pkg.common import ParameterGrid, split_train_test_with_metadata
 from rdkit import RDLogger
 from imblearn.over_sampling import SMOTE
 from sklearn.ensemble import GradientBoostingClassifier
@@ -96,14 +96,17 @@ def main(fingerprint_type, file_path, model_save_path, assay_num, fp_path, time_
     assay_name = df.columns[assay_num+1]
 
     if drop_idx:
-        y = df.iloc[:, assay_num+1].drop(drop_idx).reset_index(drop=True)
+        base_df = df.drop(index=drop_idx).reset_index(drop=True)
     else:
-        y = df.iloc[:, assay_num+1].reset_index(drop=True)
+        base_df = df.reset_index(drop=True)
+
+    y = base_df.iloc[:, assay_num+1]
 
     na_idx = y[y.isnull()].index
     y = y.drop(index=na_idx).reset_index(drop=True)
     x = x.drop(index=na_idx).reset_index(drop=True)
-############################################################################04.07 위 수정 x
+    base_df = base_df.drop(index=na_idx).reset_index(drop=True)
+
     date_today = datetime.today().strftime("%Y%m%d")
 
     # time_now를 datetime 객체로 변환
@@ -112,11 +115,11 @@ def main(fingerprint_type, file_path, model_save_path, assay_num, fp_path, time_
         random_seed = abs(int(time_now_obj.timestamp()))
     except ValueError:
         raise ValueError(f"Invalid time format for time_now: {time_now}. Expected format: 'HH-MM-SS'")
-    
-    x_train, x_test, y_train, y_test = train_test_split(
-        x, y, test_size=0.2, shuffle=True, stratify=y, random_state=random_seed
+
+    x_train, x_test, y_train, y_test = split_train_test_with_metadata(
+        x, y, base_df, file_path, assay_name,
+        random_state=random_seed, stratify=y
     )
-    
 
     # 저장 디렉토리 설정
     save_dir = f'./data_v.2/train_test_split/{data_name}/{assay_name}/{fingerprint_type}_gbt/{date_today}/{time_now}'

--- a/ToxCast_model/ToxCast_model_v.2/run_v.2/logistic.py
+++ b/ToxCast_model/ToxCast_model_v.2/run_v.2/logistic.py
@@ -10,9 +10,9 @@ import joblib
 import logging
 import numpy as np
 from tqdm import tqdm
-from sklearn.model_selection import StratifiedKFold, train_test_split
+from sklearn.model_selection import StratifiedKFold
 from sklearn.metrics import precision_score, recall_score, accuracy_score, f1_score, roc_auc_score
-from toxcast_pkg.common import ParameterGrid
+from toxcast_pkg.common import ParameterGrid, split_train_test_with_metadata
 from rdkit import RDLogger
 from imblearn.over_sampling import SMOTE
 from sklearn.linear_model import LogisticRegression
@@ -96,15 +96,17 @@ def main(fingerprint_type, file_path, model_save_path, assay_num, fp_path, time_
     assay_name = df.columns[assay_num+1]
 
     if drop_idx:
-        y = df.iloc[:, assay_num+1].drop(drop_idx).reset_index(drop=True)
+        base_df = df.drop(index=drop_idx).reset_index(drop=True)
     else:
-        y = df.iloc[:, assay_num+1].reset_index(drop=True)
+        base_df = df.reset_index(drop=True)
+
+    y = base_df.iloc[:, assay_num+1]
 
     na_idx = y[y.isnull()].index
     y = y.drop(index=na_idx).reset_index(drop=True)
     x = x.drop(index=na_idx).reset_index(drop=True)
+    base_df = base_df.drop(index=na_idx).reset_index(drop=True)
 
-############################################################################04.07 위 수정 x
     date_today = datetime.today().strftime("%Y%m%d")
 
     # time_now를 datetime 객체로 변환
@@ -113,12 +115,12 @@ def main(fingerprint_type, file_path, model_save_path, assay_num, fp_path, time_
         random_seed = abs(int(time_now_obj.timestamp()))
     except ValueError:
         raise ValueError(f"Invalid time format for time_now: {time_now}. Expected format: 'HH-MM-SS'")
-    
-    x_train, x_test, y_train, y_test = train_test_split(
-        x, y, test_size=0.2, shuffle=True, stratify=y, random_state=random_seed
+
+    x_train, x_test, y_train, y_test = split_train_test_with_metadata(
+        x, y, base_df, file_path, assay_name,
+        random_state=random_seed, stratify=y
     )
-    
-    
+
     # 저장 디렉토리 설정
     save_dir = f'./data_v.2/train_test_split/{data_name}/{assay_name}/{fingerprint_type}_logistic/{date_today}/{time_now}'
     os.makedirs(save_dir, exist_ok=True)

--- a/ToxCast_model/ToxCast_model_v.2/run_v.2/rf.py
+++ b/ToxCast_model/ToxCast_model_v.2/run_v.2/rf.py
@@ -10,9 +10,9 @@ import joblib
 import logging
 import numpy as np
 from tqdm import tqdm
-from sklearn.model_selection import StratifiedKFold, train_test_split
+from sklearn.model_selection import StratifiedKFold
 from sklearn.metrics import precision_score, recall_score, accuracy_score, f1_score, roc_auc_score
-from toxcast_pkg.common import ParameterGrid
+from toxcast_pkg.common import ParameterGrid, split_train_test_with_metadata
 from rdkit import RDLogger
 from imblearn.over_sampling import SMOTE
 from sklearn.ensemble import RandomForestClassifier
@@ -96,15 +96,17 @@ def main(fingerprint_type, file_path, model_save_path, assay_num, fp_path, time_
     assay_name = df.columns[assay_num+1]
 
     if drop_idx:
-        y = df.iloc[:, assay_num+1].drop(drop_idx).reset_index(drop=True)
+        base_df = df.drop(index=drop_idx).reset_index(drop=True)
     else:
-        y = df.iloc[:, assay_num+1].reset_index(drop=True)
+        base_df = df.reset_index(drop=True)
+
+    y = base_df.iloc[:, assay_num+1]
 
     na_idx = y[y.isnull()].index
     y = y.drop(index=na_idx).reset_index(drop=True)
     x = x.drop(index=na_idx).reset_index(drop=True)
+    base_df = base_df.drop(index=na_idx).reset_index(drop=True)
 
-############################################################################04.07 위 수정 x
     date_today = datetime.today().strftime("%Y%m%d")
     # time_now를 datetime 객체로 변환
 
@@ -113,12 +115,12 @@ def main(fingerprint_type, file_path, model_save_path, assay_num, fp_path, time_
         random_seed = abs(int(time_now_obj.timestamp()))
     except ValueError:
         raise ValueError(f"Invalid time format for time_now: {time_now}. Expected format: 'HH-MM-SS'")
-    
-    x_train, x_test, y_train, y_test = train_test_split(
-        x, y, test_size=0.2, shuffle=True, stratify=y, random_state=random_seed
+
+    x_train, x_test, y_train, y_test = split_train_test_with_metadata(
+        x, y, base_df, file_path, assay_name,
+        random_state=random_seed, stratify=y
     )
-    
-    
+
     # 저장 디렉토리 설정
     save_dir = f'./data_v.2/train_test_split/{data_name}/{assay_name}/{fingerprint_type}_rf/{date_today}/{time_now}'
     os.makedirs(save_dir, exist_ok=True)

--- a/ToxCast_model/ToxCast_model_v.2/run_v.2/xgb.py
+++ b/ToxCast_model/ToxCast_model_v.2/run_v.2/xgb.py
@@ -10,9 +10,9 @@ import joblib
 import logging
 import numpy as np
 from tqdm import tqdm
-from sklearn.model_selection import StratifiedKFold, train_test_split
+from sklearn.model_selection import StratifiedKFold
 from sklearn.metrics import precision_score, recall_score, accuracy_score, f1_score, roc_auc_score
-from toxcast_pkg.common import ParameterGrid
+from toxcast_pkg.common import ParameterGrid, split_train_test_with_metadata
 from rdkit import RDLogger
 from imblearn.over_sampling import SMOTE
 import pandas as pd
@@ -104,15 +104,17 @@ def main(fingerprint_type, file_path, model_save_path, assay_num, fp_path, time_
     assay_name = df.columns[assay_num+1]
 
     if drop_idx:
-        y = df.iloc[:, assay_num+1].drop(drop_idx).reset_index(drop=True)
+        base_df = df.drop(index=drop_idx).reset_index(drop=True)
     else:
-        y = df.iloc[:, assay_num+1].reset_index(drop=True)
+        base_df = df.reset_index(drop=True)
+
+    y = base_df.iloc[:, assay_num+1]
 
     na_idx = y[y.isnull()].index
     y = y.drop(index=na_idx).reset_index(drop=True)
     x = x.drop(index=na_idx).reset_index(drop=True)
+    base_df = base_df.drop(index=na_idx).reset_index(drop=True)
 
-############################################################################04.07 위 수정 x
     date_today = datetime.today().strftime("%Y%m%d")
 
     # time_now를 datetime 객체로 변환
@@ -121,12 +123,12 @@ def main(fingerprint_type, file_path, model_save_path, assay_num, fp_path, time_
         random_seed = abs(int(time_now_obj.timestamp()))
     except ValueError:
         raise ValueError(f"Invalid time format for time_now: {time_now}. Expected format: 'HH-MM-SS'")
-    
-    x_train, x_test, y_train, y_test = train_test_split(
-        x, y, test_size=0.2, shuffle=True, stratify=y, random_state=random_seed
+
+    x_train, x_test, y_train, y_test = split_train_test_with_metadata(
+        x, y, base_df, file_path, assay_name,
+        random_state=random_seed, stratify=y
     )
-    
-    
+
     # 저장 디렉토리 설정
     save_dir = f'./data_v.2/train_test_split/{data_name}/{assay_name}/{fingerprint_type}_xgb/{date_today}/{time_now}'
     os.makedirs(save_dir, exist_ok=True)

--- a/ToxCast_model/run/dt.py
+++ b/ToxCast_model/run/dt.py
@@ -13,9 +13,9 @@ import joblib
 import logging
 import numpy as np
 from tqdm import tqdm
-from sklearn.model_selection import StratifiedKFold, train_test_split
+from sklearn.model_selection import StratifiedKFold
 from sklearn.metrics import precision_score, recall_score, accuracy_score, f1_score, roc_auc_score
-from toxcast_pkg.common import ParameterGrid
+from toxcast_pkg.common import ParameterGrid, split_train_test_with_metadata
 from rdkit import RDLogger
 from imblearn.over_sampling import SMOTE
 from sklearn.tree import DecisionTreeClassifier
@@ -83,15 +83,19 @@ def main(fingerprint_type, file_path, model_save_path, assay_num, fp_path):
     df = pd.read_excel(file_path, sheet_name="data", header=1)
     assay_name = df.columns[assay_num+1]
     if drop_idx:
-        y = df.iloc[:, assay_num+1].drop(drop_idx).reset_index(drop=True)
+        base_df = df.drop(index=drop_idx).reset_index(drop=True)
     else:
-        y = df.iloc[:, assay_num+1].reset_index(drop=True)
+        base_df = df.reset_index(drop=True)
+    y = base_df.iloc[:, assay_num+1]
 
     na_idx = y[y.isnull()].index
     y = y.drop(index=na_idx).reset_index(drop=True)
     x = x.drop(index=na_idx).reset_index(drop=True)
+    base_df = base_df.drop(index=na_idx).reset_index(drop=True)
 
-    x_train, x_test, y_train, y_test = train_test_split(x, y, test_size=0.2, shuffle=True, random_state=42)
+    x_train, x_test, y_train, y_test = split_train_test_with_metadata(
+        x, y, base_df, file_path, assay_name
+    )
 
     params_dict = {
         'criterion': ['gini', 'entropy'],

--- a/ToxCast_model/run/gbt.py
+++ b/ToxCast_model/run/gbt.py
@@ -9,9 +9,9 @@ import warnings
 import joblib
 import logging
 from tqdm import tqdm
-from sklearn.model_selection import StratifiedKFold, train_test_split
+from sklearn.model_selection import StratifiedKFold
 from sklearn.metrics import precision_score, recall_score, accuracy_score, f1_score, roc_auc_score
-from toxcast_pkg.common import ParameterGrid
+from toxcast_pkg.common import ParameterGrid, split_train_test_with_metadata
 from rdkit import RDLogger
 from imblearn.over_sampling import SMOTE
 from sklearn.ensemble import GradientBoostingClassifier
@@ -81,15 +81,20 @@ def main(fingerprint_type, file_path, model_save_path, assay_num, fp_path):
     assay_name = df.columns[assay_num+1]
 
     if drop_idx:
-        y = df.iloc[:, assay_num+1].drop(drop_idx).reset_index(drop=True)
+        base_df = df.drop(index=drop_idx).reset_index(drop=True)
     else:
-        y = df.iloc[:, assay_num+1].reset_index(drop=True)
+        base_df = df.reset_index(drop=True)
+
+    y = base_df.iloc[:, assay_num+1]
 
     na_idx = y[y.isnull()].index
     y = y.drop(index=na_idx).reset_index(drop=True)
     x = x.drop(index=na_idx).reset_index(drop=True)
+    base_df = base_df.drop(index=na_idx).reset_index(drop=True)
 
-    x_train, x_test, y_train, y_test = train_test_split(x, y, test_size=0.2, shuffle=True, random_state=42)
+    x_train, x_test, y_train, y_test = split_train_test_with_metadata(
+        x, y, base_df, file_path, assay_name
+    )
 
     params_dict = {
         'learning_rate': [0.001, 0.005, 0.01, 0.05, 0.1],

--- a/ToxCast_model/run/logistic.py
+++ b/ToxCast_model/run/logistic.py
@@ -10,9 +10,9 @@ import joblib
 import logging
 import numpy as np
 from tqdm import tqdm
-from sklearn.model_selection import StratifiedKFold, train_test_split
+from sklearn.model_selection import StratifiedKFold
 from sklearn.metrics import precision_score, recall_score, accuracy_score, f1_score, roc_auc_score
-from toxcast_pkg.common import ParameterGrid
+from toxcast_pkg.common import ParameterGrid, split_train_test_with_metadata
 from rdkit import RDLogger
 from imblearn.over_sampling import SMOTE
 from sklearn.linear_model import LogisticRegression
@@ -81,15 +81,20 @@ def main(fingerprint_type, file_path, model_save_path, assay_num, fp_path):
     assay_name = df.columns[assay_num+1]
 
     if drop_idx:
-        y = df.iloc[:, assay_num+1].drop(drop_idx).reset_index(drop=True)
+        base_df = df.drop(index=drop_idx).reset_index(drop=True)
     else:
-        y = df.iloc[:, assay_num+1].reset_index(drop=True)
+        base_df = df.reset_index(drop=True)
+
+    y = base_df.iloc[:, assay_num+1]
 
     na_idx = y[y.isnull()].index
     y = y.drop(index=na_idx).reset_index(drop=True)
     x = x.drop(index=na_idx).reset_index(drop=True)
+    base_df = base_df.drop(index=na_idx).reset_index(drop=True)
 
-    x_train, x_test, y_train, y_test = train_test_split(x, y, test_size=0.2, shuffle=True, random_state=42)
+    x_train, x_test, y_train, y_test = split_train_test_with_metadata(
+        x, y, base_df, file_path, assay_name
+    )
 
     params_dict = {
         'C': [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 

--- a/ToxCast_model/run/rf.py
+++ b/ToxCast_model/run/rf.py
@@ -10,9 +10,9 @@ import joblib
 import logging
 import numpy as np
 from tqdm import tqdm
-from sklearn.model_selection import StratifiedKFold, train_test_split
+from sklearn.model_selection import StratifiedKFold
 from sklearn.metrics import precision_score, recall_score, accuracy_score, f1_score, roc_auc_score
-from toxcast_pkg.common import ParameterGrid
+from toxcast_pkg.common import ParameterGrid, split_train_test_with_metadata
 from rdkit import RDLogger
 from imblearn.over_sampling import SMOTE
 from sklearn.ensemble import RandomForestClassifier
@@ -81,15 +81,20 @@ def main(fingerprint_type, file_path, model_save_path, assay_num, fp_path):
     assay_name = df.columns[assay_num+1]
 
     if drop_idx:
-        y = df.iloc[:, assay_num+1].drop(drop_idx).reset_index(drop=True)
+        base_df = df.drop(index=drop_idx).reset_index(drop=True)
     else:
-        y = df.iloc[:, assay_num+1].reset_index(drop=True)
+        base_df = df.reset_index(drop=True)
+
+    y = base_df.iloc[:, assay_num+1]
 
     na_idx = y[y.isnull()].index
     y = y.drop(index=na_idx).reset_index(drop=True)
     x = x.drop(index=na_idx).reset_index(drop=True)
+    base_df = base_df.drop(index=na_idx).reset_index(drop=True)
 
-    x_train, x_test, y_train, y_test = train_test_split(x, y, test_size=0.2, shuffle=True, random_state=42)
+    x_train, x_test, y_train, y_test = split_train_test_with_metadata(
+        x, y, base_df, file_path, assay_name
+    )
 
     params_dict = {
         'n_estimators': [3, 5, 10, 15, 20, 30, 50, 90, 95, 100, 125, 130, 150],

--- a/ToxCast_model/run/xgb.py
+++ b/ToxCast_model/run/xgb.py
@@ -10,9 +10,9 @@ import joblib
 import logging
 import numpy as np
 from tqdm import tqdm
-from sklearn.model_selection import StratifiedKFold, train_test_split
+from sklearn.model_selection import StratifiedKFold
 from sklearn.metrics import precision_score, recall_score, accuracy_score, f1_score, roc_auc_score
-from toxcast_pkg.common import ParameterGrid
+from toxcast_pkg.common import ParameterGrid, split_train_test_with_metadata
 from rdkit import RDLogger
 from imblearn.over_sampling import SMOTE
 import pandas as pd
@@ -89,15 +89,20 @@ def main(fingerprint_type, file_path, model_save_path, assay_num, fp_path):
     assay_name = df.columns[assay_num+1]
 
     if drop_idx:
-        y = df.iloc[:, assay_num+1].drop(drop_idx).reset_index(drop=True)
+        base_df = df.drop(index=drop_idx).reset_index(drop=True)
     else:
-        y = df.iloc[:, assay_num+1].reset_index(drop=True)
+        base_df = df.reset_index(drop=True)
+
+    y = base_df.iloc[:, assay_num+1]
 
     na_idx = y[y.isnull()].index
     y = y.drop(index=na_idx).reset_index(drop=True)
     x = x.drop(index=na_idx).reset_index(drop=True)
+    base_df = base_df.drop(index=na_idx).reset_index(drop=True)
 
-    x_train, x_test, y_train, y_test = train_test_split(x, y, test_size=0.2, shuffle=True, random_state=42)
+    x_train, x_test, y_train, y_test = split_train_test_with_metadata(
+        x, y, base_df, file_path, assay_name
+    )
 
     params_dict = {
         'min_child_weight': [1, 2, 3, 5],

--- a/ToxCast_model/toxcast_pkg/common.py
+++ b/ToxCast_model/toxcast_pkg/common.py
@@ -1,4 +1,3 @@
-import sklearn
 import numpy as np
 import pandas as pd
 import re
@@ -11,13 +10,14 @@ from collections.abc import Iterable
 
 from sklearn.model_selection import (
     StratifiedKFold,
-    StratifiedShuffleSplit
+    StratifiedShuffleSplit,
+    train_test_split,
 )
 from sklearn.metrics import (
     precision_score,
     recall_score,
     accuracy_score,
-    f1_score
+    f1_score,
 )
 from sklearn.cross_decomposition import PLSRegression
 
@@ -49,9 +49,86 @@ def ParameterGrid(param_dict):
     
     params_grid = []
     for v in product(*values):
-        params_grid.append(dict(zip(keys, v))) 
-    
+        params_grid.append(dict(zip(keys, v)))
+
     return params_grid
+
+
+def save_split_metadata(project_dir: Path, assay_name: str,
+                        x_train: pd.DataFrame, y_train: pd.Series,
+                        x_test: pd.DataFrame, y_test: pd.Series,
+                        s_train: pd.Series | None = None,
+                        s_test: pd.Series | None = None) -> None:
+    """Save train/test split information under metadata/<assay_name>.
+
+    Each CSV contains the input features and a ``label`` column.  When
+    ``s_train``/``s_test`` are provided, a ``SMILES`` column is prepended so
+    users can trace back the original molecules.
+    """
+    meta_dir = Path(project_dir) / "metadata" / assay_name
+    meta_dir.mkdir(parents=True, exist_ok=True)
+
+    train_df = x_train.copy()
+    train_df["label"] = y_train
+    if s_train is not None:
+        train_df.insert(0, "SMILES", s_train)
+
+    test_df = x_test.copy()
+    test_df["label"] = y_test
+    if s_test is not None:
+        test_df.insert(0, "SMILES", s_test)
+
+    train_path = meta_dir / "training.csv"
+    test_path = meta_dir / "test.csv"
+    if not train_path.exists():
+        train_df.to_csv(train_path, index=False)
+    if not test_path.exists():
+        test_df.to_csv(test_path, index=False)
+
+
+def split_train_test_with_metadata(x: pd.DataFrame, y: pd.Series,
+                                   base_df: pd.DataFrame, file_path: str,
+                                   assay_name: str, test_size: float = 0.2,
+                                   random_state: int = 42,
+                                   stratify: pd.Series | None = None):
+    """Split data into train/test sets and store the split under metadata.
+
+    Parameters are identical to :func:`train_test_split` with the addition of
+    ``base_df`` which is used to extract SMILES information aligned with ``x``
+    and ``y``.
+    """
+    smiles_series = base_df["SMILES"] if "SMILES" in base_df.columns else None
+
+    if smiles_series is not None:
+        x_tr, x_te, y_tr, y_te, s_tr, s_te = train_test_split(
+            x, y, smiles_series,
+            test_size=test_size,
+            shuffle=True,
+            random_state=random_state,
+            stratify=stratify,
+        )
+        x_tr = x_tr.reset_index(drop=True)
+        x_te = x_te.reset_index(drop=True)
+        y_tr = y_tr.reset_index(drop=True)
+        y_te = y_te.reset_index(drop=True)
+        s_tr = s_tr.reset_index(drop=True)
+        s_te = s_te.reset_index(drop=True)
+        save_split_metadata(Path(file_path).parent, assay_name, x_tr, y_tr, x_te, y_te, s_tr, s_te)
+    else:
+        x_tr, x_te, y_tr, y_te = train_test_split(
+            x, y,
+            test_size=test_size,
+            shuffle=True,
+            random_state=random_state,
+            stratify=stratify,
+        )
+        x_tr = x_tr.reset_index(drop=True)
+        x_te = x_te.reset_index(drop=True)
+        y_tr = y_tr.reset_index(drop=True)
+        y_te = y_te.reset_index(drop=True)
+        save_split_metadata(Path(file_path).parent, assay_name, x_tr, y_tr, x_te, y_te)
+
+    return x_tr, x_te, y_tr, y_te
 
 
 def CV(x, y, model, params, seed):


### PR DESCRIPTION
## Summary
- save train/test splits with labels (and SMILES when available) under `metadata/<assay>`
- centralize splitting + metadata logic in `split_train_test_with_metadata`
- update training scripts to record dataset splits

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a8150cbd248320a43d7cb75d4f9e21