### PR TITLE
Support seed-aware v3 training pipeline

### DIFF
--- a/ToxCast_model/ToxCast_model_training.sh
+++ b/ToxCast_model/ToxCast_model_training.sh
@@ -41,44 +41,92 @@ EOF
 mkdir -p "${results_dir}" "${logs_dir}"
 
 if [[ "$version" == "3" ]]; then
-    train_csv=$(python - <<'EOF'
+    data_dir=$(python - <<'EOF'
 import config
-print(config.TRAIN_FILE_PATH)
+print(config.DATA_DIR)
 EOF
 )
-    val_csv=$(python - <<'EOF'
-import config
-print(config.VAL_FILE_PATH)
-EOF
-)
-    test_csv=$(python - <<'EOF'
-import config
-print(config.TEST_FILE_PATH)
-EOF
-)
-    train_fp_dir=$(python - <<'EOF'
-import config
-print(config.TRAIN_FP_PATH)
-EOF
-)
-    val_fp_dir=$(python - <<'EOF'
-import config
-print(config.VAL_FP_PATH)
-EOF
-)
-    test_fp_dir=$(python - <<'EOF'
-import config
-print(config.TEST_FP_PATH)
-EOF
-)
-    mapfile -t assays < <(python - <<'EOF'
-import config
+
+    mapfile -t seed_dirs < <(find "$data_dir" -maxdepth 1 -mindepth 1 -type d -name 'seed_*' | sort)
+    if [[ ${#seed_dirs[@]} -eq 0 ]]; then
+        echo "No seed directories found under $data_dir" >&2
+        exit 1
+    fi
+
+    for seed_dir in "${seed_dirs[@]}"; do
+        seed_name="$(basename "$seed_dir")"
+        seed_results_dir="${results_dir}/${seed_name}"
+        seed_logs_dir="${logs_dir}/${seed_name}"
+        mkdir -p "$seed_results_dir" "$seed_logs_dir"
+
+        train_csv="$seed_dir/train_df.csv"
+        val_csv="$seed_dir/val_df.csv"
+        test_csv="$seed_dir/test_df.csv"
+        [[ -f "$train_csv" ]] || train_csv="$seed_dir/train/train_df.csv"
+        [[ -f "$val_csv" ]] || val_csv="$seed_dir/val/val_df.csv"
+        [[ -f "$test_csv" ]] || test_csv="$seed_dir/test/test_df.csv"
+
+        train_fp_dir="$seed_dir/fingerprints/train"
+        val_fp_dir="$seed_dir/fingerprints/val"
+        test_fp_dir="$seed_dir/fingerprints/test"
+        [[ -d "$seed_dir/train/fingerprints" ]] && train_fp_dir="$seed_dir/train/fingerprints"
+        [[ -d "$seed_dir/val/fingerprints" ]] && val_fp_dir="$seed_dir/val/fingerprints"
+        [[ -d "$seed_dir/test/fingerprints" ]] && test_fp_dir="$seed_dir/test/fingerprints"
+
+        if [[ ! -f "$train_csv" ]]; then
+            echo "Missing train_df.csv for $seed_dir" >&2
+            continue
+        fi
+
+        mapfile -t assays < <(python - <<'EOF'
+import sys
 from toxcast_pkg.v3_data import get_assay_names_from_csv
-print('\n'.join(get_assay_names_from_csv(config.TRAIN_FILE_PATH)))
+print("\n".join(get_assay_names_from_csv(sys.argv[1])))
 EOF
-)
-else
-    file_path=$(python - <<'EOF'
+"$train_csv")
+
+        for assay_name in "${assays[@]}"; do
+            assay_dir="${seed_logs_dir}/${assay_name}"
+            mkdir -p "$assay_dir"
+            for model in "${models[@]}"; do
+                for fingerprint in "${fingerprints[@]}"; do
+                    save_dir="${seed_results_dir}/${assay_name}_${model}_${fingerprint}"
+                    mkdir -p "$save_dir"
+
+                    log_file="${assay_dir}/${assay_name}_${model}_${fingerprint}.log"
+                    err_file="${assay_dir}/${assay_name}_${model}_${fingerprint}.err"
+
+                    echo "[$(date)] Running ${seed_name}/${assay_name}_${model}_${fingerprint}"
+
+                    python "./${run_dir}/${model}.py" \
+                        --fingerprint_type "$fingerprint" \
+                        --train_csv "$train_csv" \
+                        --val_csv "$val_csv" \
+                        --test_csv "$test_csv" \
+                        --train_fp_dir "$train_fp_dir" \
+                        --val_fp_dir "$val_fp_dir" \
+                        --test_fp_dir "$test_fp_dir" \
+                        --assay_name "$assay_name" \
+                        --model_save_path "$save_dir" \
+                        --random_state 42 \
+                        >"$log_file" 2>"$err_file"
+                done
+            done
+        done
+
+        python -m toxcast_pkg.v3_summary \
+            --seed-dir "$seed_dir" \
+            --results-dir "$seed_results_dir" \
+            --output "$seed_results_dir/summary.csv"
+    done
+
+    python -m toxcast_pkg.v3_summary \
+        --results-dir "$results_dir" \
+        --aggregate "$results_dir/summary_all_seeds.csv"
+    exit 0
+fi
+
+file_path=$(python - <<'EOF'
 import config, os
 from toxcast_pkg.common import find_single_excel_file
 p = config.TRAIN_FILE_PATH
@@ -87,12 +135,14 @@ if os.path.isdir(p):
 print(p)
 EOF
 )
-    fp_path=$(python - <<'EOF'
+
+fp_path=$(python - <<'EOF'
 import config
 print(config.TRAIN_FP_PATH)
 EOF
 )
-    mapfile -t assays < <(python - <<'EOF'
+
+mapfile -t assays < <(python - <<'EOF'
 import pandas as pd
 import sys
 path = sys.argv[1]
@@ -100,7 +150,6 @@ df = pd.read_excel(path, sheet_name='data', header=None)
 print('\n'.join(str(v) for v in df.iloc[0,2:].tolist()))
 EOF
 "${file_path}")
-fi
 
 max_jobs=45
 current_jobs=0
@@ -119,29 +168,13 @@ for assay_name in "${assays[@]}"; do
 
             echo "[$(date)] Running ${assay_name}/${assay_name}_${fingerprint}_${model}"
 
-            if [[ "$version" == "3" ]]; then
-                python "./${run_dir}/${model}.py" \
-                    --fingerprint_type "$fingerprint" \
-                    --train_csv "$train_csv" \
-                    --val_csv "$val_csv" \
-                    --test_csv "$test_csv" \
-                    --train_fp_dir "$train_fp_dir" \
-                    --val_fp_dir "$val_fp_dir" \
-                    --test_fp_dir "$test_fp_dir" \
-                    --assay_name "$assay_name" \
-                    --assay_index "$assay_index" \
-                    --model_save_path "$save_dir" \
-                    --random_state 42 \
-                    >"$log_file" 2>"$err_file" &
-            else
-                python "./${run_dir}/${model}.py" \
-                    --fingerprint_type "$fingerprint" \
-                    --file_path "$file_path" \
-                    --model_save_path "$save_dir" \
-                    --assay_num "$assay_index" \
-                    --fp_path "$fp_path" \
-                    >"$log_file" 2>"$err_file" &
-            fi
+            python "./${run_dir}/${model}.py" \
+                --fingerprint_type "$fingerprint" \
+                --file_path "$file_path" \
+                --model_save_path "$save_dir" \
+                --assay_num "$assay_index" \
+                --fp_path "$fp_path" \
+                >"$log_file" 2>"$err_file" &
 
             ((current_jobs++))
             if (( current_jobs >= max_jobs )); then

--- a/ToxCast_model/config.py
+++ b/ToxCast_model/config.py
@@ -39,9 +39,16 @@ MODELS = ["dt", "rf", "xgb", "gbt", "logistic"]
 FINGERPRINTS = ["MACCS", "Morgan", "RDKit", "Pattern", "Layered"]
 
 if VERSION == 3:
-    TRAIN_DIR = BASE_DIR / "train"
-    VAL_DIR = BASE_DIR / "val"
-    TEST_DIR = BASE_DIR / "test"
+    DATA_DIR = BASE_DIR / "data"
+    RESULTS_DIR = BASE_DIR / "results"
+    LOGS_DIR = BASE_DIR / "logs"
+
+    # default fallback paths mimic the legacy single-split layout.  They are
+    # primarily used by helper scripts that operate on a single seed.  The
+    # training launcher resolves concrete seed-specific paths at runtime.
+    TRAIN_DIR = DATA_DIR / "seed_0" / "train"
+    VAL_DIR = DATA_DIR / "seed_0" / "val"
+    TEST_DIR = DATA_DIR / "seed_0" / "test"
 
     TRAIN_FILE_PATH = TRAIN_DIR / "train_df.csv"
     VAL_FILE_PATH = VAL_DIR / "val_df.csv"
@@ -53,7 +60,6 @@ if VERSION == 3:
 
     FINGERPRINT_DIR = TRAIN_FP_PATH
     FINGERPRINT_OUTPUT_DIR = FINGERPRINT_DIR
-    RESULTS_DIR = BASE_DIR / "results"
 
     SMILES_INPUT_PATH = TRAIN_FILE_PATH
 
@@ -101,17 +107,26 @@ def validate_paths():
     """Ensure required input files exist for the selected version."""
 
     if VERSION == 3:
-        required_paths = [
-            TRAIN_FILE_PATH,
-            VAL_FILE_PATH,
-            TEST_FILE_PATH,
-            TRAIN_FP_PATH,
-            VAL_FP_PATH,
-            TEST_FP_PATH,
-        ]
-        for path in required_paths:
-            if not Path(path).exists():
-                raise FileNotFoundError(f"Required path missing for VERSION=3: {path}")
+        data_dir = Path(DATA_DIR)
+        if not data_dir.exists():
+            raise FileNotFoundError(f"Data directory missing for VERSION=3: {data_dir}")
+
+        seed_dirs = sorted(p for p in data_dir.iterdir() if p.is_dir() and p.name.startswith("seed_"))
+        if not seed_dirs:
+            raise FileNotFoundError(
+                f"No seed directories found under {data_dir}. Expected seed_* directories."
+            )
+
+        for seed_dir in seed_dirs:
+            for split in ("train", "val", "test"):
+                csv_candidates = [
+                    seed_dir / f"{split}_df.csv",
+                    seed_dir / split / f"{split}_df.csv",
+                ]
+                if not any(path.exists() for path in csv_candidates):
+                    raise FileNotFoundError(
+                        f"Missing {split}_df.csv for {seed_dir}. Checked: {csv_candidates}"
+                    )
     else:
         from toxcast_pkg.common import find_single_excel_file, check_required_sheets
 

--- a/ToxCast_model/run_v3/dt.py
+++ b/ToxCast_model/run_v3/dt.py
@@ -63,16 +63,30 @@ def main() -> None:
     fingerprint_type = args.fingerprint_type
     assay_name = resolve_assay_name(args)
 
-    train_dir = Path(args.train_fp_dir).parent
-    val_dir = Path(args.val_fp_dir).parent
-    test_dir = Path(args.test_fp_dir).parent
+    train_csv_path = Path(args.train_csv)
+    val_csv_path = Path(args.val_csv) if args.val_csv else None
+    test_csv_path = Path(args.test_csv) if args.test_csv else None
+
+    def normalise_fp_dir(csv_path: Path | None, fp_arg: str | None) -> Path | None:
+        if fp_arg:
+            return Path(fp_arg)
+        if csv_path is None:
+            return None
+        return csv_path.parent / "fingerprints"
+
+    train_fp_dir = normalise_fp_dir(train_csv_path, getattr(args, "train_fp_dir", None))
+    val_fp_dir = normalise_fp_dir(val_csv_path, getattr(args, "val_fp_dir", None))
+    test_fp_dir = normalise_fp_dir(test_csv_path, getattr(args, "test_fp_dir", None))
 
     train, val, test = prepare_datasets(
         fingerprint_type,
         assay_name,
-        train_dir,
-        val_dir,
-        test_dir,
+        train_csv_path,
+        val_csv_path,
+        test_csv_path,
+        train_fp_dir,
+        val_fp_dir,
+        test_fp_dir,
     )
 
     model_save_path = Path(args.model_save_path)
@@ -112,6 +126,7 @@ def main() -> None:
     train_x, train_y = apply_smote(train.features, train.labels, args.random_state)
     final_model.fit(train_x, train_y)
 
+    val_metrics = None
     if val and val.labels is not None:
         val_pred = final_model.predict(val.features)
         val_prob = final_model.predict_proba(val.features)[:, 1]
@@ -122,6 +137,7 @@ def main() -> None:
         logging.info("Holdout Validation Accuracy: %s", val_metrics["accuracy"])
         logging.info("Holdout Validation AUC: %s", val_metrics["roc_auc"])
 
+    test_metrics = None
     if test and test.labels is not None:
         test_pred = final_model.predict(test.features)
         test_prob = final_model.predict_proba(test.features)[:, 1]
@@ -132,9 +148,23 @@ def main() -> None:
         logging.info("Test Accuracy: %s", test_metrics["accuracy"])
         logging.info("Test AUC: %s", test_metrics["roc_auc"])
 
-    model_filename = model_save_path / f"{assay_name}_best_model_{fingerprint_type}_dt.joblib"
+    model_filename = model_save_path / "model.joblib"
     joblib.dump(final_model, model_filename)
     logging.info("Best model saved as %s", model_filename)
+
+    report = {
+        "assay_name": assay_name,
+        "model": "dt",
+        "fingerprint": fingerprint_type,
+        "best_params": best_params,
+        "cv_metrics": {metric: result[metric][best_key] for metric in METRIC_KEYS},
+        "cv_metrics_mean": best_metrics,
+        "validation_metrics": val_metrics,
+        "test_metrics": test_metrics,
+        "random_state": args.random_state,
+        "estimator": f"{final_model.__module__}.{final_model.__class__.__name__}",
+    }
+    save_results(report, model_save_path / "metrics.json")
 
 
 if __name__ == "__main__":

--- a/ToxCast_model/run_v3/gbt.py
+++ b/ToxCast_model/run_v3/gbt.py
@@ -63,16 +63,30 @@ def main() -> None:
     fingerprint_type = args.fingerprint_type
     assay_name = resolve_assay_name(args)
 
-    train_dir = Path(args.train_fp_dir).parent
-    val_dir = Path(args.val_fp_dir).parent
-    test_dir = Path(args.test_fp_dir).parent
+    train_csv_path = Path(args.train_csv)
+    val_csv_path = Path(args.val_csv) if args.val_csv else None
+    test_csv_path = Path(args.test_csv) if args.test_csv else None
+
+    def normalise_fp_dir(csv_path: Path | None, fp_arg: str | None) -> Path | None:
+        if fp_arg:
+            return Path(fp_arg)
+        if csv_path is None:
+            return None
+        return csv_path.parent / "fingerprints"
+
+    train_fp_dir = normalise_fp_dir(train_csv_path, getattr(args, "train_fp_dir", None))
+    val_fp_dir = normalise_fp_dir(val_csv_path, getattr(args, "val_fp_dir", None))
+    test_fp_dir = normalise_fp_dir(test_csv_path, getattr(args, "test_fp_dir", None))
 
     train, val, test = prepare_datasets(
         fingerprint_type,
         assay_name,
-        train_dir,
-        val_dir,
-        test_dir,
+        train_csv_path,
+        val_csv_path,
+        test_csv_path,
+        train_fp_dir,
+        val_fp_dir,
+        test_fp_dir,
     )
 
     model_save_path = Path(args.model_save_path)
@@ -112,6 +126,7 @@ def main() -> None:
     train_x, train_y = apply_smote(train.features, train.labels, args.random_state)
     final_model.fit(train_x, train_y)
 
+    val_metrics = None
     if val and val.labels is not None:
         val_pred = final_model.predict(val.features)
         val_prob = final_model.predict_proba(val.features)[:, 1]
@@ -122,6 +137,7 @@ def main() -> None:
         logging.info("Holdout Validation Accuracy: %s", val_metrics["accuracy"])
         logging.info("Holdout Validation AUC: %s", val_metrics["roc_auc"])
 
+    test_metrics = None
     if test and test.labels is not None:
         test_pred = final_model.predict(test.features)
         test_prob = final_model.predict_proba(test.features)[:, 1]
@@ -132,9 +148,23 @@ def main() -> None:
         logging.info("Test Accuracy: %s", test_metrics["accuracy"])
         logging.info("Test AUC: %s", test_metrics["roc_auc"])
 
-    model_filename = model_save_path / f"{assay_name}_best_model_{fingerprint_type}_gbt.joblib"
+    model_filename = model_save_path / "model.joblib"
     joblib.dump(final_model, model_filename)
     logging.info("Best model saved as %s", model_filename)
+
+    report = {
+        "assay_name": assay_name,
+        "model": "gbt",
+        "fingerprint": fingerprint_type,
+        "best_params": best_params,
+        "cv_metrics": {metric: result[metric][best_key] for metric in METRIC_KEYS},
+        "cv_metrics_mean": best_metrics,
+        "validation_metrics": val_metrics,
+        "test_metrics": test_metrics,
+        "random_state": args.random_state,
+        "estimator": f"{final_model.__module__}.{final_model.__class__.__name__}",
+    }
+    save_results(report, model_save_path / "metrics.json")
 
 
 if __name__ == "__main__":

--- a/ToxCast_model/run_v3/logistic.py
+++ b/ToxCast_model/run_v3/logistic.py
@@ -63,16 +63,30 @@ def main() -> None:
     fingerprint_type = args.fingerprint_type
     assay_name = resolve_assay_name(args)
 
-    train_dir = Path(args.train_fp_dir).parent
-    val_dir = Path(args.val_fp_dir).parent
-    test_dir = Path(args.test_fp_dir).parent
+    train_csv_path = Path(args.train_csv)
+    val_csv_path = Path(args.val_csv) if args.val_csv else None
+    test_csv_path = Path(args.test_csv) if args.test_csv else None
+
+    def normalise_fp_dir(csv_path: Path | None, fp_arg: str | None) -> Path | None:
+        if fp_arg:
+            return Path(fp_arg)
+        if csv_path is None:
+            return None
+        return csv_path.parent / "fingerprints"
+
+    train_fp_dir = normalise_fp_dir(train_csv_path, getattr(args, "train_fp_dir", None))
+    val_fp_dir = normalise_fp_dir(val_csv_path, getattr(args, "val_fp_dir", None))
+    test_fp_dir = normalise_fp_dir(test_csv_path, getattr(args, "test_fp_dir", None))
 
     train, val, test = prepare_datasets(
         fingerprint_type,
         assay_name,
-        train_dir,
-        val_dir,
-        test_dir,
+        train_csv_path,
+        val_csv_path,
+        test_csv_path,
+        train_fp_dir,
+        val_fp_dir,
+        test_fp_dir,
     )
 
     model_save_path = Path(args.model_save_path)
@@ -110,6 +124,7 @@ def main() -> None:
     train_x, train_y = apply_smote(train.features, train.labels, args.random_state)
     final_model.fit(train_x, train_y)
 
+    val_metrics = None
     if val and val.labels is not None:
         val_pred = final_model.predict(val.features)
         val_prob = final_model.predict_proba(val.features)[:, 1]
@@ -120,6 +135,7 @@ def main() -> None:
         logging.info("Holdout Validation Accuracy: %s", val_metrics["accuracy"])
         logging.info("Holdout Validation AUC: %s", val_metrics["roc_auc"])
 
+    test_metrics = None
     if test and test.labels is not None:
         test_pred = final_model.predict(test.features)
         test_prob = final_model.predict_proba(test.features)[:, 1]
@@ -130,9 +146,23 @@ def main() -> None:
         logging.info("Test Accuracy: %s", test_metrics["accuracy"])
         logging.info("Test AUC: %s", test_metrics["roc_auc"])
 
-    model_filename = model_save_path / f"{assay_name}_best_model_{fingerprint_type}_logistic.joblib"
+    model_filename = model_save_path / "model.joblib"
     joblib.dump(final_model, model_filename)
     logging.info("Best model saved as %s", model_filename)
+
+    report = {
+        "assay_name": assay_name,
+        "model": "logistic",
+        "fingerprint": fingerprint_type,
+        "best_params": best_params,
+        "cv_metrics": {metric: result[metric][best_key] for metric in METRIC_KEYS},
+        "cv_metrics_mean": best_metrics,
+        "validation_metrics": val_metrics,
+        "test_metrics": test_metrics,
+        "random_state": args.random_state,
+        "estimator": f"{final_model.__module__}.{final_model.__class__.__name__}",
+    }
+    save_results(report, model_save_path / "metrics.json")
 
 
 if __name__ == "__main__":

--- a/ToxCast_model/run_v3/rf.py
+++ b/ToxCast_model/run_v3/rf.py
@@ -63,16 +63,30 @@ def main() -> None:
     fingerprint_type = args.fingerprint_type
     assay_name = resolve_assay_name(args)
 
-    train_dir = Path(args.train_fp_dir).parent
-    val_dir = Path(args.val_fp_dir).parent
-    test_dir = Path(args.test_fp_dir).parent
+    train_csv_path = Path(args.train_csv)
+    val_csv_path = Path(args.val_csv) if args.val_csv else None
+    test_csv_path = Path(args.test_csv) if args.test_csv else None
+
+    def normalise_fp_dir(csv_path: Path | None, fp_arg: str | None) -> Path | None:
+        if fp_arg:
+            return Path(fp_arg)
+        if csv_path is None:
+            return None
+        return csv_path.parent / "fingerprints"
+
+    train_fp_dir = normalise_fp_dir(train_csv_path, getattr(args, "train_fp_dir", None))
+    val_fp_dir = normalise_fp_dir(val_csv_path, getattr(args, "val_fp_dir", None))
+    test_fp_dir = normalise_fp_dir(test_csv_path, getattr(args, "test_fp_dir", None))
 
     train, val, test = prepare_datasets(
         fingerprint_type,
         assay_name,
-        train_dir,
-        val_dir,
-        test_dir,
+        train_csv_path,
+        val_csv_path,
+        test_csv_path,
+        train_fp_dir,
+        val_fp_dir,
+        test_fp_dir,
     )
 
     model_save_path = Path(args.model_save_path)
@@ -111,6 +125,7 @@ def main() -> None:
     train_x, train_y = apply_smote(train.features, train.labels, args.random_state)
     final_model.fit(train_x, train_y)
 
+    val_metrics = None
     if val and val.labels is not None:
         val_pred = final_model.predict(val.features)
         val_prob = final_model.predict_proba(val.features)[:, 1]
@@ -121,6 +136,7 @@ def main() -> None:
         logging.info("Holdout Validation Accuracy: %s", val_metrics["accuracy"])
         logging.info("Holdout Validation AUC: %s", val_metrics["roc_auc"])
 
+    test_metrics = None
     if test and test.labels is not None:
         test_pred = final_model.predict(test.features)
         test_prob = final_model.predict_proba(test.features)[:, 1]
@@ -131,9 +147,23 @@ def main() -> None:
         logging.info("Test Accuracy: %s", test_metrics["accuracy"])
         logging.info("Test AUC: %s", test_metrics["roc_auc"])
 
-    model_filename = model_save_path / f"{assay_name}_best_model_{fingerprint_type}_rf.joblib"
+    model_filename = model_save_path / "model.joblib"
     joblib.dump(final_model, model_filename)
     logging.info("Best model saved as %s", model_filename)
+
+    report = {
+        "assay_name": assay_name,
+        "model": "rf",
+        "fingerprint": fingerprint_type,
+        "best_params": best_params,
+        "cv_metrics": {metric: result[metric][best_key] for metric in METRIC_KEYS},
+        "cv_metrics_mean": best_metrics,
+        "validation_metrics": val_metrics,
+        "test_metrics": test_metrics,
+        "random_state": args.random_state,
+        "estimator": f"{final_model.__module__}.{final_model.__class__.__name__}",
+    }
+    save_results(report, model_save_path / "metrics.json")
 
 
 if __name__ == "__main__":

--- a/ToxCast_model/run_v3/utils.py
+++ b/ToxCast_model/run_v3/utils.py
@@ -96,13 +96,24 @@ def evaluate_predictions(y_true: pd.Series, y_pred: np.ndarray, y_prob: np.ndarr
 def prepare_datasets(
     fingerprint_type: str,
     assay_name: str,
-    train_dir: Path,
-    val_dir: Path | None,
-    test_dir: Path | None,
+    train_csv: Path,
+    val_csv: Path | None,
+    test_csv: Path | None,
+    train_fp_dir: Path | None = None,
+    val_fp_dir: Path | None = None,
+    test_fp_dir: Path | None = None,
 ) -> Tuple[SplitData, SplitData | None, SplitData | None]:
-    train = load_split_data(train_dir, fingerprint_type, assay_name)
-    val = load_split_data(val_dir, fingerprint_type, assay_name) if val_dir else None
-    test = load_split_data(test_dir, fingerprint_type, assay_name) if test_dir else None
+    train = load_split_data(train_csv, fingerprint_type, assay_name, train_fp_dir)
+    val = (
+        load_split_data(val_csv, fingerprint_type, assay_name, val_fp_dir)
+        if val_csv is not None
+        else None
+    )
+    test = (
+        load_split_data(test_csv, fingerprint_type, assay_name, test_fp_dir)
+        if test_csv is not None
+        else None
+    )
 
     ensure_matching_indices(*(d for d in (train, val, test) if d is not None))
     return train, val, test

--- a/ToxCast_model/run_v3/xgb.py
+++ b/ToxCast_model/run_v3/xgb.py
@@ -69,16 +69,30 @@ def main() -> None:
     fingerprint_type = args.fingerprint_type
     assay_name = resolve_assay_name(args)
 
-    train_dir = Path(args.train_fp_dir).parent
-    val_dir = Path(args.val_fp_dir).parent
-    test_dir = Path(args.test_fp_dir).parent
+    train_csv_path = Path(args.train_csv)
+    val_csv_path = Path(args.val_csv) if args.val_csv else None
+    test_csv_path = Path(args.test_csv) if args.test_csv else None
+
+    def normalise_fp_dir(csv_path: Path | None, fp_arg: str | None) -> Path | None:
+        if fp_arg:
+            return Path(fp_arg)
+        if csv_path is None:
+            return None
+        return csv_path.parent / "fingerprints"
+
+    train_fp_dir = normalise_fp_dir(train_csv_path, getattr(args, "train_fp_dir", None))
+    val_fp_dir = normalise_fp_dir(val_csv_path, getattr(args, "val_fp_dir", None))
+    test_fp_dir = normalise_fp_dir(test_csv_path, getattr(args, "test_fp_dir", None))
 
     train, val, test = prepare_datasets(
         fingerprint_type,
         assay_name,
-        train_dir,
-        val_dir,
-        test_dir,
+        train_csv_path,
+        val_csv_path,
+        test_csv_path,
+        train_fp_dir,
+        val_fp_dir,
+        test_fp_dir,
     )
 
     model_save_path = Path(args.model_save_path)
@@ -119,6 +133,7 @@ def main() -> None:
     train_x, train_y = apply_smote(train.features, train.labels, args.random_state)
     final_model.fit(train_x, train_y)
 
+    val_metrics = None
     if val and val.labels is not None:
         val_pred = final_model.predict(val.features)
         val_prob = final_model.predict_proba(val.features)[:, 1]
@@ -129,6 +144,7 @@ def main() -> None:
         logging.info("Holdout Validation Accuracy: %s", val_metrics["accuracy"])
         logging.info("Holdout Validation AUC: %s", val_metrics["roc_auc"])
 
+    test_metrics = None
     if test and test.labels is not None:
         test_pred = final_model.predict(test.features)
         test_prob = final_model.predict_proba(test.features)[:, 1]
@@ -139,9 +155,23 @@ def main() -> None:
         logging.info("Test Accuracy: %s", test_metrics["accuracy"])
         logging.info("Test AUC: %s", test_metrics["roc_auc"])
 
-    model_filename = model_save_path / f"{assay_name}_best_model_{fingerprint_type}_xgb.joblib"
+    model_filename = model_save_path / "model.joblib"
     joblib.dump(final_model, model_filename)
     logging.info("Best model saved as %s", model_filename)
+
+    report = {
+        "assay_name": assay_name,
+        "model": "xgb",
+        "fingerprint": fingerprint_type,
+        "best_params": best_params,
+        "cv_metrics": {metric: result[metric][best_key] for metric in METRIC_KEYS},
+        "cv_metrics_mean": best_metrics,
+        "validation_metrics": val_metrics,
+        "test_metrics": test_metrics,
+        "random_state": args.random_state,
+        "estimator": f"{final_model.__module__}.{final_model.__class__.__name__}",
+    }
+    save_results(report, model_save_path / "metrics.json")
 
 
 if __name__ == "__main__":

--- a/ToxCast_model/toxcast_pkg/v3_data.py
+++ b/ToxCast_model/toxcast_pkg/v3_data.py
@@ -2,9 +2,10 @@
 
 This module centralises the logic required to load the ``train``/``val``/``test``
 CSV files and their associated fingerprint matrices.  Version 3 of the
-ToxCast pipeline expects each split directory to contain a ``*_df.csv`` file
-and a ``fingerprints`` sub-directory that mirrors the layout described in the
-user instructions.
+ToxCast pipeline searches for ``seed_*`` directories that contain
+``*_df.csv`` files.  Fingerprint matrices are loaded from an accompanying
+``fingerprints`` directory when available, or generated on the fly from the
+SMILES column if they are missing.
 """
 
 from __future__ import annotations
@@ -14,6 +15,8 @@ from pathlib import Path
 from typing import Iterable
 
 import pandas as pd
+
+from toxcast_pkg.smiles2fing import Smiles2Fing
 
 
 DEFAULT_NON_ASSAY_COLUMNS = ("DTXSID", "SMILES")
@@ -114,39 +117,74 @@ class SplitData:
         return SplitData(features=features, labels=labels, smiles=smiles)
 
 
+def _ensure_fingerprint_matrix(
+    df: pd.DataFrame,
+    fingerprint_dir: Path,
+    fingerprint_type: str,
+) -> tuple[pd.DataFrame, list[int]]:
+    """Return the fingerprint matrix, generating it if necessary."""
+
+    fingerprint_dir.mkdir(parents=True, exist_ok=True)
+    fp_path = fingerprint_dir / f"{fingerprint_type}.csv"
+    drop_path = fingerprint_dir / f"{fingerprint_type}_dropidx.csv"
+
+    if fp_path.exists():
+        features = pd.read_csv(fp_path)
+        drop_idx = read_drop_indices(drop_path)
+        return features, drop_idx
+
+    smiles = df.get("SMILES")
+    if smiles is None:
+        raise ValueError(
+            "SMILES column missing; unable to generate fingerprint matrix."
+        )
+
+    drop_idx, features = Smiles2Fing(smiles.astype(str), fingerprint_type)
+    features.to_csv(fp_path, index=False)
+    pd.Series(drop_idx).to_csv(drop_path, index=False, header=False)
+    return features, drop_idx
+
+
 def load_split_data(
-    split_dir: Path,
+    split_source: Path,
     fingerprint_type: str,
     assay_name: str | None,
+    fingerprint_dir: Path | None = None,
 ) -> SplitData:
-    """Load the features/labels for a given split directory.
+    """Load the features/labels for a given split.
 
     Parameters
     ----------
-    split_dir:
-        Directory containing ``*_df.csv`` and the ``fingerprints`` folder.
+    split_source:
+        Directory containing ``*_df.csv`` or the CSV file itself.
     fingerprint_type:
-        One of ``MACCS``, ``Morgan`` ... matching the CSV files in
-        ``fingerprints``.
+        One of ``MACCS``, ``Morgan`` ... identifying the fingerprint matrix.
     assay_name:
         Name of the target column.  If ``None`` the labels field will be
         returned as ``None`` (useful for pure prediction inputs).
+    fingerprint_dir:
+        Optional explicit directory containing fingerprint CSV files.
     """
 
-    split_dir = Path(split_dir)
-    df_path = split_dir / f"{split_dir.name}_df.csv"
+    split_source = Path(split_source)
+    if split_source.is_dir():
+        df_path = split_source / f"{split_source.name}_df.csv"
+        base_dir = split_source
+    else:
+        df_path = split_source
+        base_dir = split_source.parent
+
     if not df_path.exists():
         raise FileNotFoundError(f"{df_path} does not exist")
 
     df = load_split_dataframe(df_path)
 
-    fingerprint_dir = split_dir / "fingerprints"
-    fp_path = fingerprint_dir / f"{fingerprint_type}.csv"
-    if not fp_path.exists():
-        raise FileNotFoundError(f"Fingerprint file missing: {fp_path}")
+    if fingerprint_dir is None:
+        fingerprint_dir = base_dir / "fingerprints"
+    else:
+        fingerprint_dir = Path(fingerprint_dir)
 
-    features = pd.read_csv(fp_path)
-    drop_idx = read_drop_indices(fingerprint_dir / f"{fingerprint_type}_dropidx.csv")
+    features, drop_idx = _ensure_fingerprint_matrix(df, fingerprint_dir, fingerprint_type)
     if drop_idx:
         features = features.drop(index=drop_idx).reset_index(drop=True)
         df = df.drop(index=drop_idx).reset_index(drop=True)

--- a/ToxCast_model/toxcast_pkg/v3_summary.py
+++ b/ToxCast_model/toxcast_pkg/v3_summary.py
@@ -1,0 +1,154 @@
+"""Summarise ToxCast v3 training runs across multiple seeds."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Dict, Iterable, Optional
+
+import pandas as pd
+
+from toxcast_pkg.v3_data import DEFAULT_NON_ASSAY_COLUMNS, load_split_dataframe
+
+COLUMN_ORDER = [
+    "AEID",
+    "Database",
+    "Training",
+    "Positive (%)",
+    "Model",
+    "MF/MD",
+    "Algorithm",
+    "Test F1",
+    "Test Precision",
+    "Test Recall",
+    "Test AUC",
+    "Test Accuracy",
+    "Validation F1",
+    "Validation Precision",
+    "Validation Recall",
+    "Validation AUC",
+    "Validation Accuracy",
+]
+
+
+def _find_train_csv(seed_dir: Path) -> Path:
+    candidates = [
+        seed_dir / "train_df.csv",
+        seed_dir / "train" / "train_df.csv",
+    ]
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+    raise FileNotFoundError(f"Unable to locate train_df.csv under {seed_dir}")
+
+
+def _compute_training_stats(train_csv: Path) -> Dict[str, Dict[str, Optional[float]]]:
+    df = load_split_dataframe(train_csv)
+    assays = [col for col in df.columns if col not in DEFAULT_NON_ASSAY_COLUMNS]
+    stats: Dict[str, Dict[str, Optional[float]]] = {}
+    for assay in assays:
+        series = df[assay].dropna()
+        count = int(series.size)
+        positive_pct: Optional[float]
+        if count == 0:
+            positive_pct = None
+        else:
+            try:
+                positive_pct = float(series.mean() * 100)
+            except Exception:
+                positive_pct = None
+        stats[assay] = {"count": count if count > 0 else None, "positive_pct": positive_pct}
+    return stats
+
+
+def _format_ratio(value: Optional[float]) -> str:
+    if value is None:
+        return ""
+    return f"{value:.2f}"
+
+
+def build_seed_summary(seed_dir: Path, results_dir: Path) -> pd.DataFrame:
+    train_csv = _find_train_csv(seed_dir)
+    stats = _compute_training_stats(train_csv)
+
+    rows = []
+    for metrics_path in sorted(results_dir.glob("*/metrics.json")):
+        with metrics_path.open("r", encoding="utf-8") as f:
+            record = json.load(f)
+
+        assay = record.get("assay_name", "")
+        stat_info = stats.get(assay, {"count": None, "positive_pct": None})
+
+        test_metrics = record.get("test_metrics") or {}
+        val_metrics = record.get("validation_metrics") or {}
+
+        row = {
+            "AEID": "",
+            "Database": assay,
+            "Training": stat_info.get("count"),
+            "Positive (%)": _format_ratio(stat_info.get("positive_pct")),
+            "Model": record.get("model"),
+            "MF/MD": record.get("fingerprint"),
+            "Algorithm": record.get("estimator"),
+            "Test F1": test_metrics.get("f1"),
+            "Test Precision": test_metrics.get("precision"),
+            "Test Recall": test_metrics.get("recall"),
+            "Test AUC": test_metrics.get("roc_auc"),
+            "Test Accuracy": test_metrics.get("accuracy"),
+            "Validation F1": val_metrics.get("f1"),
+            "Validation Precision": val_metrics.get("precision"),
+            "Validation Recall": val_metrics.get("recall"),
+            "Validation AUC": val_metrics.get("roc_auc"),
+            "Validation Accuracy": val_metrics.get("accuracy"),
+        }
+        rows.append(row)
+
+    df = pd.DataFrame(rows, columns=COLUMN_ORDER)
+    df = df.sort_values(["Database", "Model", "MF/MD"], na_position="last").reset_index(drop=True)
+    return df
+
+
+def aggregate_summaries(results_dir: Path) -> pd.DataFrame:
+    frames = []
+    for seed_dir in sorted(results_dir.glob("seed_*")):
+        summary_path = seed_dir / "summary.csv"
+        if summary_path.exists():
+            df = pd.read_csv(summary_path)
+            df.insert(0, "Seed", seed_dir.name)
+            frames.append(df)
+    if not frames:
+        return pd.DataFrame(columns=["Seed", *COLUMN_ORDER])
+    return pd.concat(frames, ignore_index=True)
+
+
+def parse_args(argv: Optional[Iterable[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Summarise ToxCast v3 training outputs")
+    parser.add_argument("--seed-dir", type=Path, help="Directory containing seed data (train/val/test CSVs)")
+    parser.add_argument("--results-dir", type=Path, required=True, help="Directory with training outputs")
+    parser.add_argument("--output", type=Path, help="Path to write the per-seed summary CSV")
+    parser.add_argument("--aggregate", type=Path, help="Path to write the aggregated summary CSV")
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[Iterable[str]] = None) -> None:
+    args = parse_args(argv)
+
+    if args.output:
+        if not args.seed_dir:
+            raise ValueError("--seed-dir must be provided when --output is specified")
+        summary_df = build_seed_summary(args.seed_dir, args.results_dir)
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        summary_df.to_csv(args.output, index=False)
+
+    if args.aggregate:
+        aggregate_df = aggregate_summaries(args.results_dir)
+        if aggregate_df.empty:
+            return
+        args.aggregate.parent.mkdir(parents=True, exist_ok=True)
+        aggregate_df.to_csv(args.aggregate, index=False)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/slurm/run_training.sh
+++ b/slurm/run_training.sh
@@ -85,38 +85,128 @@ if [ -z "$SLURM_LAUNCHED" ]; then
 fi
 
 # Prepare directories
-input_excel=("$project_dir"/*.xlsx)
 results_dir="$project_dir/results"
 logs_dir="$project_dir/logs"
-fp_dir="$project_dir/fingerprints"
-metadata_file="$project_dir/metadata.json"
-mkdir -p "$results_dir" "$logs_dir" "$fp_dir"
-: > "$metadata_file"
+mkdir -p "$results_dir" "$logs_dir"
 
-# Generate fingerprints only if missing (skip for version 3)
-if [ "$version" != "3" ]; then
-    if [ -z "$(ls -A "$fp_dir" 2>/dev/null)" ]; then
-        PYTHONPATH="$model_dir" python -m toxcast_pkg.smiles2fing
-    fi
-fi
+fingerprints=(MACCS Morgan Layered Pattern RDKit)
+models=(rf logistic xgb gbt dt)
 
 if [ "$version" = "3" ]; then
-    train_csv="$project_dir/train/train_df.csv"
-    val_csv="$project_dir/val/val_df.csv"
-    test_csv="$project_dir/test/test_df.csv"
-    train_fp_dir="$project_dir/train/fingerprints"
-    val_fp_dir="$project_dir/val/fingerprints"
-    test_fp_dir="$project_dir/test/fingerprints"
-    mapfile -t assays < <(PYTHONPATH="$base_model_dir" python - <<'PY'
+    data_dir="$project_dir/data"
+    if [ ! -d "$data_dir" ]; then
+        echo "Data directory not found for VERSION=3: $data_dir" >&2
+        exit 1
+    fi
+
+    mapfile -t seed_dirs < <(find "$data_dir" -maxdepth 1 -mindepth 1 -type d -name 'seed_*' | sort)
+    if [ ${#seed_dirs[@]} -eq 0 ]; then
+        echo "No seed directories detected under $data_dir" >&2
+        exit 1
+    fi
+
+    for seed_dir in "${seed_dirs[@]}"; do
+        seed_name="$(basename "$seed_dir")"
+        seed_results_dir="$results_dir/$seed_name"
+        seed_logs_dir="$logs_dir/$seed_name"
+        mkdir -p "$seed_results_dir" "$seed_logs_dir"
+
+        train_csv="$seed_dir/train_df.csv"
+        val_csv="$seed_dir/val_df.csv"
+        test_csv="$seed_dir/test_df.csv"
+        if [ ! -f "$train_csv" ]; then
+            train_csv="$seed_dir/train/train_df.csv"
+        fi
+        if [ ! -f "$val_csv" ]; then
+            val_csv="$seed_dir/val/val_df.csv"
+        fi
+        if [ ! -f "$test_csv" ]; then
+            test_csv="$seed_dir/test/test_df.csv"
+        fi
+
+        train_fp_dir="$seed_dir/fingerprints/train"
+        val_fp_dir="$seed_dir/fingerprints/val"
+        test_fp_dir="$seed_dir/fingerprints/test"
+        if [ -d "$seed_dir/train/fingerprints" ]; then
+            train_fp_dir="$seed_dir/train/fingerprints"
+        fi
+        if [ -d "$seed_dir/val/fingerprints" ]; then
+            val_fp_dir="$seed_dir/val/fingerprints"
+        fi
+        if [ -d "$seed_dir/test/fingerprints" ]; then
+            test_fp_dir="$seed_dir/test/fingerprints"
+        fi
+
+        if [ ! -f "$train_csv" ]; then
+            echo "Missing train_df.csv for $seed_dir" >&2
+            continue
+        fi
+
+        mapfile -t assays < <(PYTHONPATH="$base_model_dir" python - <<'PY'
 import sys
 from toxcast_pkg.v3_data import get_assay_names_from_csv
-path=sys.argv[1]
-print('\n'.join(get_assay_names_from_csv(path)))
+print("\n".join(get_assay_names_from_csv(sys.argv[1])))
 PY
 "$train_csv")
-else
-    # Extract assay names from Excel
-    mapfile -t assays < <(python - "$input_excel" <<'PY'
+
+        for assay in "${assays[@]}"; do
+            for fp in "${fingerprints[@]}"; do
+                for model in "${models[@]}"; do
+                    save_dir="$seed_results_dir/${assay}_${model}_${fp}"
+                    mkdir -p "$save_dir"
+                    log_file="$seed_logs_dir/${assay}/${assay}_${model}_${fp}.log"
+                    mkdir -p "$(dirname "$log_file")"
+                    echo "[$(date '+%F %T')] START ${seed_name}:${assay}_${model}_${fp}" >> "$slurm_out"
+                    start_time=$(date +%s)
+                    set +e
+                    PYTHONPATH="$model_dir" python "$model_dir/$run_subdir/${model}.py" \
+                        --fingerprint_type "$fp" \
+                        --train_csv "$train_csv" \
+                        --val_csv "$val_csv" \
+                        --test_csv "$test_csv" \
+                        --train_fp_dir "$train_fp_dir" \
+                        --val_fp_dir "$val_fp_dir" \
+                        --test_fp_dir "$test_fp_dir" \
+                        --assay_name "$assay" \
+                        --model_save_path "$save_dir" \
+                        >"$log_file" 2>&1
+                    exit_code=$?
+                    set -e
+                    end_time=$(date +%s)
+                    echo "[$(date '+%F %T')] END ${seed_name}:${assay}_${model}_${fp}" >> "$slurm_out"
+                    if [ $exit_code -ne 0 ]; then
+                        echo "Training failed for $seed_name/$assay/$fp/$model. See $log_file" >&2
+                    fi
+                done
+            done
+        done
+
+        PYTHONPATH="$model_dir" python -m toxcast_pkg.v3_summary \
+            --seed-dir "$seed_dir" \
+            --results-dir "$seed_results_dir" \
+            --output "$seed_results_dir/summary.csv"
+    done
+
+    PYTHONPATH="$model_dir" python -m toxcast_pkg.v3_summary \
+        --results-dir "$results_dir" \
+        --aggregate "$results_dir/summary_all_seeds.csv"
+
+    echo "[$(date '+%F %T')] Training complete" >> "$slurm_out"
+    exit 0
+fi
+
+input_excel=("$project_dir"/*.xlsx)
+fp_dir="$project_dir/fingerprints"
+metadata_file="$project_dir/metadata.json"
+mkdir -p "$fp_dir"
+: > "$metadata_file"
+
+if [ -z "$(ls -A "$fp_dir" 2>/dev/null)" ]; then
+    PYTHONPATH="$model_dir" python -m toxcast_pkg.smiles2fing
+fi
+
+# Extract assay names from Excel
+mapfile -t assays < <(python - "$input_excel" <<'PY'
 import sys, zipfile, xml.etree.ElementTree as ET
 xlsx=sys.argv[1]
 with zipfile.ZipFile(xlsx) as z:
@@ -136,12 +226,7 @@ for c in row.findall('a:c', ns):
     vals.append(val)
 print('\n'.join(vals[2:]))
 PY
-    )
-fi
-
-# Define fingerprints and models
-fingerprints=(MACCS Morgan Layered Pattern RDKit)
-models=(rf logistic xgb gbt dt)
+)
 
 assay_index=0
 for assay in "${assays[@]}"; do
@@ -154,28 +239,13 @@ for assay in "${assays[@]}"; do
             echo "[$(date '+%F %T')] START ${assay}_${fp}_${model}" >> "$slurm_out"
             start_time=$(date +%s)
             set +e
-            if [ "$version" = "3" ]; then
-                PYTHONPATH="$model_dir" python "$model_dir/$run_subdir/${model}.py" \
-                    --fingerprint_type "$fp" \
-                    --train_csv "$train_csv" \
-                    --val_csv "$val_csv" \
-                    --test_csv "$test_csv" \
-                    --train_fp_dir "$train_fp_dir" \
-                    --val_fp_dir "$val_fp_dir" \
-                    --test_fp_dir "$test_fp_dir" \
-                    --assay_name "$assay" \
-                    --assay_index "$assay_index" \
-                    --model_save_path "$save_dir" \
-                    >"$log_file" 2>&1
-            else
-                PYTHONPATH="$model_dir" python "$model_dir/$run_subdir/${model}.py" \
-                    --fingerprint_type "$fp" \
-                    --file_path "$input_excel" \
-                    --model_save_path "$save_dir" \
-                    --assay_num "$assay_index" \
-                    --fp_path "$fp_dir" \
-                    >"$log_file" 2>&1
-            fi
+            PYTHONPATH="$model_dir" python "$model_dir/$run_subdir/${model}.py" \
+                --fingerprint_type "$fp" \
+                --file_path "$input_excel" \
+                --model_save_path "$save_dir" \
+                --assay_num "$assay_index" \
+                --fp_path "$fp_dir" \
+                >"$log_file" 2>&1
             exit_code=$?
             set -e
             end_time=$(date +%s)


### PR DESCRIPTION
## Summary
- update the v3 configuration to work with data/seed_* directories and validate required split files.
- teach the v3 data loader and trainers to generate fingerprints on demand, accept explicit split paths, and emit per-run metrics JSON alongside the model artifact.
- rework the training launchers to iterate seeds, collect per-seed outputs, and add a summary utility that assembles the requested report columns.

## Testing
- python -m compileall ToxCast_model/run_v3 ToxCast_model/toxcast_pkg

------
https://chatgpt.com/codex/tasks/task_e_68d4f5a9c97483209d1d8075fb8a0076