### PR TITLE
Fix inline Python argument passing in training scripts

### DIFF
--- a/ToxCast_model/ToxCast_model_training.sh
+++ b/ToxCast_model/ToxCast_model_training.sh
@@ -78,12 +78,12 @@ EOF
             continue
         fi
 
-        mapfile -t assays < <(python - <<'EOF'
+        mapfile -t assays < <(python - "$train_csv" <<'EOF'
 import sys
 from toxcast_pkg.v3_data import get_assay_names_from_csv
 print("\n".join(get_assay_names_from_csv(sys.argv[1])))
 EOF
-"$train_csv")
+)
 
         for assay_name in "${assays[@]}"; do
             assay_dir="${seed_logs_dir}/${assay_name}"
@@ -142,14 +142,14 @@ print(config.TRAIN_FP_PATH)
 EOF
 )
 
-mapfile -t assays < <(python - <<'EOF'
+mapfile -t assays < <(python - "$file_path" <<'EOF'
 import pandas as pd
 import sys
 path = sys.argv[1]
 df = pd.read_excel(path, sheet_name='data', header=None)
 print('\n'.join(str(v) for v in df.iloc[0,2:].tolist()))
 EOF
-"${file_path}")
+)
 
 max_jobs=45
 current_jobs=0

--- a/slurm/run_training.sh
+++ b/slurm/run_training.sh
@@ -165,12 +165,12 @@ PYGEN
             fi
         done
 
-        mapfile -t assays < <(PYTHONPATH="$base_model_dir" python - <<'PY'
+        mapfile -t assays < <(PYTHONPATH="$base_model_dir" python - "$train_csv" <<'PY'
 import sys
 from toxcast_pkg.v3_data import get_assay_names_from_csv
 print("\n".join(get_assay_names_from_csv(sys.argv[1])))
 PY
-"$train_csv")
+)
 
         for assay in "${assays[@]}"; do
             for fp in "${fingerprints[@]}"; do


### PR DESCRIPTION
## Summary
- ensure the inline Python helpers in the training launchers receive the CSV or Excel path as an argument
- prevent IndexError exceptions when collecting assay names for both the direct and Slurm training scripts

## Testing
- not run (reason: shell scripts updated only)

------
https://chatgpt.com/codex/tasks/task_e_68d5051c267c832086c2ecbd8a4b1193