### PR TITLE
Sanitize project paths before creating log directories

### DIFF
--- a/slurm/run_prediction.sh
+++ b/slurm/run_prediction.sh
@@ -10,6 +10,10 @@ source ~/anaconda3/etc/profile.d/conda.sh
 conda activate toxcast_env
 
 # Resolve script directory both when run directly and within a Slurm job
+strip_carriage_returns() {
+    printf '%s' "${1//$'\r'/}"
+}
+
 if [ -n "$SLURM_SUBMIT_DIR" ]; then
     script_dir="$SLURM_SUBMIT_DIR"
 else
@@ -49,6 +53,7 @@ import config
 print(config.BASE_DIR)
 PY
 )
+project_dir=$(strip_carriage_returns "$project_dir")
 project_name="$(basename "$project_dir")"
 
 # Resolve mode from config

--- a/slurm/run_training.sh
+++ b/slurm/run_training.sh
@@ -3,6 +3,10 @@
 # Convenience script to train models for a project directory
 set -e
 
+strip_carriage_returns() {
+    printf '%s' "${1//$'\r'/}"
+}
+
 job_mode="${SLURM_JOB_MODE:-controller}"
 
 # Load required modules for GPU execution
@@ -32,8 +36,10 @@ import config
 print(config.BASE_DIR)
 PY
 )
+default_project_dir=$(strip_carriage_returns "$default_project_dir")
 
 project_dir="${1:-$default_project_dir}"
+project_dir=$(strip_carriage_returns "$project_dir")
 project_name="$(basename "$project_dir")"
 project_logs_dir="$project_dir/logs"
 mkdir -p "$project_dir" "$project_logs_dir"


### PR DESCRIPTION
## Summary
- strip any stray carriage return characters from config-derived project paths before creating log directories in the Slurm training and prediction launchers

## Testing
- Not run (deployment scripts require the target HPC environment)


------
https://chatgpt.com/codex/tasks/task_e_68d6179f05208320a8cd4b957f2eb7d2