### PR TITLE
Add configurable Slurm submission for v3 training

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,31 @@ Install dependencies with conda using `environment.yml` or via `pip install -r r
 
 The `ToxCast_model/run` directory contains standalone scripts for each algorithm. They perform cross-validation to select the best model and save it as a joblib file for later prediction.
 
+### Slurm-based VERSION=3 training
+
+For large VERSION=3 experiments you can orchestrate GPU training directly on
+Slurm without exceeding the submission quota:
+
+1. Configure your experiment in `ToxCast_model/config.py` and ensure
+   `OBJECTS = ["prediction", "training"]`, `OBJECT = 1`, and `VERSION = 3`.
+2. Review `slurm/training_config.yaml`. The file controls project paths,
+   available seeds, assay/model/fingerprint combinations, resource requests,
+   queue throttling and environment setup (modules and conda).
+3. Submit the jobs from the repository root:
+
+   ```bash
+   python slurm/submit_v3_training.py
+   ```
+
+   Use `--dry-run` to inspect the planned submissions without calling
+   `sbatch`.
+
+Each job trains a single assay/model/fingerprint combination sequentially over
+all configured seeds, writes the logs under `experiments/<PROJECT>/logs`, and
+saves models under `experiments/<PROJECT>/results`. Queue length is monitored to
+avoid overwhelming the scheduler, and a summary job is scheduled automatically
+after the training jobs finish.
+
 ## Prediction
 
 `ToxCast_model/prediction/Predict_data.py` loads trained models specified in `config.py` and generates predictions for each assay. The script appends the original SMILES strings and writes an Excel file with the predictions.

--- a/slurm/submit_v3_training.py
+++ b/slurm/submit_v3_training.py
@@ -1,0 +1,452 @@
+#!/usr/bin/env python
+"""Submit VERSION=3 training jobs based on ``training_config.yaml``."""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import getpass
+import importlib.util
+import itertools
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Iterable, Sequence
+
+import yaml
+
+
+@dataclasses.dataclass
+class SeedEntry:
+    name: str
+    path: Path
+
+
+@dataclasses.dataclass
+class Combo:
+    assay: str
+    model: str
+    fingerprint: str
+
+    @property
+    def label(self) -> str:
+        return f"{self.assay}_{self.model}_{self.fingerprint}"
+
+
+class SubmissionError(RuntimeError):
+    pass
+
+
+def load_yaml(path: Path) -> dict:
+    with path.open("r", encoding="utf-8") as fh:
+        return yaml.safe_load(fh)
+
+
+def load_config_module(path: Path):
+    spec = importlib.util.spec_from_file_location("toxcast_config", path)
+    if spec is None or spec.loader is None:
+        raise SubmissionError(f"Unable to import config module from {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def ensure_training_v3(config_module) -> None:
+    objects = getattr(config_module, "OBJECTS", None)
+    object_idx = getattr(config_module, "OBJECT", None)
+    if not objects or object_idx is None:
+        raise SubmissionError("config.py must define OBJECTS and OBJECT")
+    try:
+        mode = objects[object_idx]
+    except Exception as exc:  # pragma: no cover - defensive
+        raise SubmissionError("Unable to resolve OBJECT from config.py") from exc
+    if mode != "training":
+        raise SubmissionError(
+            f"config.py specifies OBJECT={object_idx} -> {mode!r}. Training submissions require 'training'."
+        )
+    version = getattr(config_module, "VERSION", None)
+    if version != 3:
+        raise SubmissionError(
+            f"VERSION={version!r} in config.py. This launcher only supports VERSION=3."
+        )
+
+
+def resolve_path(base: Path | None, default: Path) -> Path:
+    return (base if base else default).expanduser().resolve()
+
+
+def discover_seeds(data_dir: Path, include: Sequence[str], pattern: str) -> list[SeedEntry]:
+    if include:
+        seeds = []
+        for name in include:
+            seed_path = data_dir / name
+            if not seed_path.is_dir():
+                raise SubmissionError(f"Configured seed directory missing: {seed_path}")
+            seeds.append(SeedEntry(name=name, path=seed_path.resolve()))
+        return seeds
+
+    seed_paths = sorted(p for p in data_dir.glob(pattern) if p.is_dir())
+    if not seed_paths:
+        raise SubmissionError(f"No seed directories found in {data_dir} (pattern={pattern!r})")
+    return [SeedEntry(name=p.name, path=p.resolve()) for p in seed_paths]
+
+
+def resolve_seed_train_csv(seed: SeedEntry) -> Path:
+    candidates = [
+        seed.path / "train_df.csv",
+        seed.path / "train" / "train_df.csv",
+    ]
+    for cand in candidates:
+        if cand.is_file():
+            return cand
+    raise SubmissionError(f"Missing train_df.csv for seed {seed.name} ({seed.path})")
+
+
+def discover_assays(train_csv: Path, model_dir: Path) -> list[str]:
+    sys.path.insert(0, str(model_dir))
+    try:
+        from toxcast_pkg.v3_data import get_assay_names_from_csv
+    except ImportError as exc:  # pragma: no cover - environment dependent
+        raise SubmissionError(
+            "toxcast_pkg.v3_data could not be imported. Ensure PYTHONPATH includes the model directory."
+        ) from exc
+    assay_names = list(get_assay_names_from_csv(str(train_csv)))
+    if not assay_names:
+        raise SubmissionError(f"No assays discovered in {train_csv}")
+    return assay_names
+
+
+def sanitise_job_name(name: str) -> str:
+    return "".join(ch if ch.isalnum() or ch in "_-" else "_" for ch in name)[:200]
+
+
+def write_seed_file(seeds: Iterable[SeedEntry], path: Path) -> None:
+    with path.open("w", encoding="utf-8") as fh:
+        for seed in seeds:
+            fh.write(f"{seed.path}|{seed.name}\n")
+
+
+def count_queue(user: str, max_queue: int | None) -> int:
+    if max_queue is None:
+        return 0
+    try:
+        cmd = ["squeue", "-u", user, "-h"]
+        result = subprocess.run(cmd, check=False, capture_output=True, text=True)
+    except FileNotFoundError:
+        return 0
+    if result.returncode != 0:
+        return 0
+    lines = [line for line in result.stdout.splitlines() if line.strip()]
+    return len(lines)
+
+
+def wait_for_queue(throttle_cfg: dict) -> None:
+    max_queue = throttle_cfg.get("max_queue")
+    if not max_queue:
+        return
+    poll = throttle_cfg.get("poll_interval_sec", 30)
+    user = getpass.getuser()
+    while True:
+        queued = count_queue(user, max_queue)
+        if queued < max_queue:
+            return
+        print(
+            f"[throttle] Current queue length {queued} exceeds limit {max_queue}. Sleeping {poll}s...",
+            file=sys.stderr,
+        )
+        time.sleep(poll)
+
+
+def run_command(cmd: Sequence[str]) -> subprocess.CompletedProcess:
+    return subprocess.run(cmd, check=False, capture_output=True, text=True)
+
+
+def submit_job(
+    worker_script: Path,
+    combo: Combo,
+    env: dict,
+    slurm_cfg: dict,
+    log_dir: Path,
+) -> str:
+    export_parts = ["ALL"]
+    for key, value in env.items():
+        export_parts.append(f"{key}={value}")
+    export_arg = ",".join(export_parts)
+
+    partitions = slurm_cfg.get("partitions") or [None]
+    gres = slurm_cfg.get("gres")
+    cpus = slurm_cfg.get("cpus_per_task")
+    mem = slurm_cfg.get("mem")
+    time_limit = slurm_cfg.get("time")
+
+    job_name = sanitise_job_name(env.get("JOB_LABEL", combo.label))
+    stdout_path = log_dir / f"{job_name}_%j.out"
+    stderr_path = log_dir / f"{job_name}_%j.err"
+
+    for idx, partition in enumerate(partitions):
+        cmd = ["sbatch", "--parsable"]
+        if partition:
+            cmd.append(f"--partition={partition}")
+        if gres:
+            cmd.append(f"--gres={gres}")
+        if cpus:
+            cmd.append(f"--cpus-per-task={cpus}")
+        if mem:
+            cmd.append(f"--mem={mem}")
+        if time_limit:
+            cmd.append(f"--time={time_limit}")
+        cmd.extend(
+            [
+                f"--job-name={job_name}",
+                f"--output={stdout_path}",
+                f"--error={stderr_path}",
+                f"--export={export_arg}",
+                str(worker_script),
+            ]
+        )
+        result = run_command(cmd)
+        if result.returncode == 0 and result.stdout.strip():
+            job_id = result.stdout.strip().splitlines()[0]
+            print(f"Submitted {combo.label} on partition {partition or 'default'} as JobID {job_id}")
+            return job_id
+
+        stderr = result.stderr.strip()
+        failure_reason = stderr or result.stdout.strip() or "unknown error"
+        print(
+            f"Failed to submit {combo.label} on partition {partition or 'default'}: {failure_reason}",
+            file=sys.stderr,
+        )
+        if idx == len(partitions) - 1:
+            raise SubmissionError(f"All partition submissions failed for {combo.label}")
+        time.sleep(2)
+
+    raise SubmissionError(f"Unable to submit job for {combo.label}")
+
+
+def submit_summary_job(
+    script_dir: Path,
+    project_dir: Path,
+    model_dir: Path,
+    run_subdir: str,
+    base_model_dir: Path,
+    slurm_cfg: dict,
+    summary_cfg: dict,
+    log_dir: Path,
+    dependencies: Sequence[str],
+) -> None:
+    if not summary_cfg.get("enabled", False):
+        return
+
+    summary_script = script_dir / summary_cfg.get("script", "run_training.sh")
+    if not summary_script.exists():
+        raise SubmissionError(f"Summary script not found: {summary_script}")
+
+    partition = summary_cfg.get("partition") or (slurm_cfg.get("partitions") or [None])[0]
+    gres = summary_cfg.get("gres") or slurm_cfg.get("gres")
+    cpus = summary_cfg.get("cpus_per_task") or slurm_cfg.get("cpus_per_task")
+    mem = summary_cfg.get("mem") or slurm_cfg.get("mem")
+    time_limit = summary_cfg.get("time") or slurm_cfg.get("time")
+    dependency_type = "afterany" if summary_cfg.get("depends_on_fail") else "afterok"
+
+    export_arg = ",".join(
+        [
+            "ALL",
+            f"SLURM_JOB_MODE=summary",
+            f"PROJECT_DIR={project_dir}",
+            f"MODEL_DIR={model_dir}",
+            f"RUN_SUBDIR={run_subdir}",
+            f"BASE_MODEL_DIR={base_model_dir}",
+        ]
+    )
+
+    job_name = sanitise_job_name(f"summary_{project_dir.name}")
+    stdout_path = log_dir / f"{job_name}_%j.out"
+    stderr_path = log_dir / f"{job_name}_%j.err"
+
+    dependency = f"{dependency_type}:" + ":".join(dependencies)
+    cmd = ["sbatch", "--parsable", f"--dependency={dependency}"]
+    if partition:
+        cmd.append(f"--partition={partition}")
+    if gres:
+        cmd.append(f"--gres={gres}")
+    if cpus:
+        cmd.append(f"--cpus-per-task={cpus}")
+    if mem:
+        cmd.append(f"--mem={mem}")
+    if time_limit:
+        cmd.append(f"--time={time_limit}")
+    cmd.extend(
+        [
+            f"--job-name={job_name}",
+            f"--output={stdout_path}",
+            f"--error={stderr_path}",
+            f"--export={export_arg}",
+            str(summary_script),
+            str(project_dir),
+        ]
+    )
+
+    result = run_command(cmd)
+    if result.returncode != 0 or not result.stdout.strip():
+        stderr = result.stderr.strip()
+        failure_reason = stderr or result.stdout.strip() or "unknown error"
+        raise SubmissionError(f"Failed to submit summary job: {failure_reason}")
+
+    job_id = result.stdout.strip().splitlines()[0]
+    print(f"Scheduled summary job {job_id} ({job_name}) with dependency on {len(dependencies)} jobs")
+
+
+def build_env(
+    combo: Combo,
+    project_dir: Path,
+    model_dir: Path,
+    run_subdir: str,
+    logs_dir: Path,
+    results_dir: Path,
+    seed_file: Path,
+    env_cfg: dict,
+    random_state: int | None,
+) -> dict:
+    env = {
+        "PROJECT_DIR": str(project_dir),
+        "MODEL_DIR": str(model_dir),
+        "RUN_SUBDIR": run_subdir,
+        "ASSAY_NAME": combo.assay,
+        "MODEL_NAME": combo.model,
+        "FINGERPRINT_NAME": combo.fingerprint,
+        "SEED_FILE": str(seed_file),
+        "LOGS_DIR": str(logs_dir),
+        "RESULTS_DIR": str(results_dir),
+        "PYTHON_BIN": env_cfg.get("python", "python"),
+        "PYTHONPATH_BASE": str(model_dir),
+        "JOB_LABEL": sanitise_job_name(f"{project_dir.name}_{combo.label}"),
+    }
+    module_cfg = env_cfg.get("module", {})
+    env["MODULE_INIT"] = module_cfg.get("init", "")
+    env["MODULE_PURGE"] = "1" if module_cfg.get("purge", True) else "0"
+    env["ENV_MODULES"] = ",".join(module_cfg.get("load", []))
+    conda_cfg = env_cfg.get("conda", {})
+    env["CONDA_SETUP"] = conda_cfg.get("setup", "")
+    env["CONDA_ENV"] = conda_cfg.get("env", "")
+    if random_state is not None:
+        env["RANDOM_STATE"] = str(random_state)
+    return env
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Submit v3 training jobs from YAML configuration")
+    parser.add_argument(
+        "--config",
+        default=Path(__file__).with_name("training_config.yaml"),
+        type=Path,
+        help="Path to training configuration YAML file",
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Print actions without calling sbatch")
+    args = parser.parse_args(argv)
+
+    cfg_path = args.config.expanduser().resolve()
+    if not cfg_path.exists():
+        raise SubmissionError(f"Configuration file not found: {cfg_path}")
+
+    config = load_yaml(cfg_path) or {}
+
+    project_cfg = config.get("project", {})
+    config_path = Path(project_cfg.get("config_path", "../ToxCast_model/config.py")).expanduser()
+    if not config_path.is_file():
+        raise SubmissionError(f"config.py not found at {config_path}")
+
+    config_module = load_config_module(config_path)
+    ensure_training_v3(config_module)
+
+    base_dir = resolve_path(project_cfg.get("base_dir"), getattr(config_module, "BASE_DIR"))
+    data_dir = resolve_path(project_cfg.get("data_dir"), getattr(config_module, "DATA_DIR"))
+    logs_dir = resolve_path(project_cfg.get("logs_dir"), getattr(config_module, "LOGS_DIR", base_dir / "logs"))
+    results_dir = resolve_path(project_cfg.get("results_dir"), getattr(config_module, "RESULTS_DIR", base_dir / "results"))
+
+    seed_cfg = project_cfg.get("seeds", {})
+    include_seeds = seed_cfg.get("include", []) or []
+    pattern = seed_cfg.get("pattern", "seed_*")
+    seeds = discover_seeds(data_dir, include_seeds, pattern)
+
+    worker_seed_file = logs_dir / "seed_list.txt"
+    worker_seed_file.parent.mkdir(parents=True, exist_ok=True)
+    write_seed_file(seeds, worker_seed_file)
+
+    model_dir = Path(getattr(config_module, "ROOT_DIR"))
+    run_subdir = config.get("training", {}).get("run_subdir", "run_v3")
+
+    assays_cfg = config.get("assays", {})
+    assays = assays_cfg.get("include") or []
+    if not assays:
+        first_train_csv = resolve_seed_train_csv(seeds[0])
+        assays = discover_assays(first_train_csv, model_dir)
+
+    training_cfg = config.get("training", {})
+    models = training_cfg.get("models") or list(getattr(config_module, "MODELS"))
+    fingerprints = training_cfg.get("fingerprints") or list(getattr(config_module, "FINGERPRINTS"))
+    random_state = training_cfg.get("random_state")
+
+    combos = [Combo(assay=a, model=m, fingerprint=f) for a, m, f in itertools.product(assays, models, fingerprints)]
+
+    slurm_cfg = config.get("slurm", {})
+    max_jobs = slurm_cfg.get("max_jobs")
+    if max_jobs and len(combos) > max_jobs:
+        raise SubmissionError(
+            f"Configuration would submit {len(combos)} jobs which exceeds max_jobs={max_jobs}. "
+            "Adjust the assay/model/fingerprint lists or increase the limit."
+        )
+
+    worker_script = Path(__file__).with_name("train_combo_worker.sh")
+    if not worker_script.exists():
+        raise SubmissionError(f"Worker script missing: {worker_script}")
+
+    slurm_log_dir = config.get("logging", {}).get("slurm_dir")
+    if slurm_log_dir:
+        slurm_log_dir = Path(slurm_log_dir).expanduser().resolve()
+    else:
+        slurm_log_dir = logs_dir / "slurm"
+    slurm_log_dir.mkdir(parents=True, exist_ok=True)
+
+    env_cfg = config.get("environment", {})
+
+    if args.dry_run or training_cfg.get("dry_run", False):
+        print("[dry-run] The following jobs would be submitted:")
+        for combo in combos:
+            env = build_env(combo, base_dir, model_dir, run_subdir, logs_dir, results_dir, worker_seed_file, env_cfg, random_state)
+            print(f"  - {combo.label} -> sbatch with env {env}")
+        return 0
+
+    throttle_cfg = slurm_cfg.get("throttle", {})
+    job_ids: list[str] = []
+    for combo in combos:
+        wait_for_queue(throttle_cfg)
+        env = build_env(combo, base_dir, model_dir, run_subdir, logs_dir, results_dir, worker_seed_file, env_cfg, random_state)
+        job_id = submit_job(worker_script, combo, env, slurm_cfg, slurm_log_dir)
+        job_ids.append(job_id)
+
+    summary_cfg = training_cfg.get("summary", {})
+    if job_ids:
+        submit_summary_job(
+            script_dir=worker_script.parent,
+            project_dir=base_dir,
+            model_dir=model_dir,
+            run_subdir=run_subdir,
+            base_model_dir=model_dir,
+            slurm_cfg=slurm_cfg,
+            summary_cfg=summary_cfg,
+            log_dir=slurm_log_dir,
+            dependencies=job_ids,
+        )
+
+    print(f"Submitted {len(job_ids)} training jobs.")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except SubmissionError as exc:
+        print(f"[ERROR] {exc}", file=sys.stderr)
+        raise SystemExit(1)

--- a/slurm/train_combo_worker.sh
+++ b/slurm/train_combo_worker.sh
@@ -1,0 +1,180 @@
+#!/bin/bash
+
+set -euo pipefail
+trap 'echo "[ERR] line:$LINENO cmd:${BASH_COMMAND}" >&2' ERR
+shopt -s inherit_errexit 2>/dev/null || true
+
+DEBUG="${DEBUG:-0}"
+dbg() { [ "$DEBUG" -eq 1 ] && echo "DEBUG: $*" >&2; }
+
+strip_cr() { printf '%s' "${1//$'\r'/}"; }
+
+resolve_seed_paths() {
+    if [ $# -lt 1 ] || [ -z "$1" ]; then
+        echo "resolve_seed_paths: seed directory argument required" >&2
+        return 1
+    fi
+
+    local seed_dir="$1"
+
+    train_csv="$seed_dir/train_df.csv"
+    val_csv="$seed_dir/val_df.csv"
+    test_csv="$seed_dir/test_df.csv"
+    if [ ! -f "$train_csv" ]; then train_csv="$seed_dir/train/train_df.csv"; fi
+    if [ ! -f "$val_csv" ]; then val_csv="$seed_dir/val/val_df.csv"; fi
+    if [ ! -f "$test_csv" ]; then test_csv="$seed_dir/test/test_df.csv"; fi
+
+    train_fp_dir="$seed_dir/fingerprints/train"
+    val_fp_dir="$seed_dir/fingerprints/val"
+    test_fp_dir="$seed_dir/fingerprints/test"
+    if [ -d "$seed_dir/train/fingerprints" ]; then train_fp_dir="$seed_dir/train/fingerprints"; fi
+    if [ -d "$seed_dir/val/fingerprints" ]; then val_fp_dir="$seed_dir/val/fingerprints"; fi
+    if [ -d "$seed_dir/test/fingerprints" ]; then test_fp_dir="$seed_dir/test/fingerprints"; fi
+}
+
+require_var() {
+    local name="$1"
+    if [ -z "${!name:-}" ]; then
+        echo "Missing required environment variable: $name" >&2
+        exit 1
+    fi
+}
+
+require_var PROJECT_DIR
+require_var MODEL_DIR
+require_var RUN_SUBDIR
+require_var ASSAY_NAME
+require_var MODEL_NAME
+require_var FINGERPRINT_NAME
+require_var SEED_FILE
+
+PROJECT_DIR=$(strip_cr "$PROJECT_DIR")
+MODEL_DIR=$(strip_cr "$MODEL_DIR")
+RUN_SUBDIR=$(strip_cr "$RUN_SUBDIR")
+ASSAY_NAME=$(strip_cr "$ASSAY_NAME")
+MODEL_NAME=$(strip_cr "$MODEL_NAME")
+FINGERPRINT_NAME=$(strip_cr "$FINGERPRINT_NAME")
+SEED_FILE=$(strip_cr "$SEED_FILE")
+
+LOGS_DIR=$(strip_cr "${LOGS_DIR:-$PROJECT_DIR/logs}")
+RESULTS_DIR=$(strip_cr "${RESULTS_DIR:-$PROJECT_DIR/results}")
+PYTHON_BIN=$(strip_cr "${PYTHON_BIN:-python}")
+PYTHONPATH_BASE=$(strip_cr "${PYTHONPATH_BASE:-$MODEL_DIR}")
+RANDOM_STATE=$(strip_cr "${RANDOM_STATE:-}")
+ENV_MODULE_INIT=$(strip_cr "${MODULE_INIT:-}")
+ENV_MODULE_PURGE=$(strip_cr "${MODULE_PURGE:-1}")
+ENV_MODULES=$(strip_cr "${ENV_MODULES:-}")
+CONDA_SETUP=$(strip_cr "${CONDA_SETUP:-}")
+CONDA_ENV=$(strip_cr "${CONDA_ENV:-}")
+JOB_LABEL=$(strip_cr "${JOB_LABEL:-${ASSAY_NAME}_${MODEL_NAME}_${FINGERPRINT_NAME}}")
+
+if [ ! -f "$SEED_FILE" ]; then
+    echo "Seed file not found: $SEED_FILE" >&2
+    exit 1
+fi
+
+mkdir -p "$LOGS_DIR" "$RESULTS_DIR"
+
+if [ -n "$ENV_MODULE_INIT" ] && [ -f "$ENV_MODULE_INIT" ]; then
+    # shellcheck disable=SC1090
+    source "$ENV_MODULE_INIT"
+fi
+
+if command -v module >/dev/null 2>&1; then
+    if [ "$ENV_MODULE_PURGE" = "1" ] || [ "$ENV_MODULE_PURGE" = "true" ]; then
+        module purge || true
+    fi
+    IFS=',' read -r -a __module_list <<< "$ENV_MODULES"
+    for __m in "${__module_list[@]}"; do
+        if [ -n "$__m" ]; then
+            module load "$__m"
+        fi
+    done
+fi
+
+if [ -n "$CONDA_SETUP" ]; then
+    if [ ! -f "$CONDA_SETUP" ]; then
+        echo "Conda setup script not found: $CONDA_SETUP" >&2
+        exit 1
+    fi
+    # shellcheck disable=SC1090
+    source "$CONDA_SETUP"
+    if [ -n "$CONDA_ENV" ]; then
+        conda activate "$CONDA_ENV"
+    fi
+fi
+
+if [ -n "$PYTHONPATH_BASE" ]; then
+    export PYTHONPATH="$PYTHONPATH_BASE:${PYTHONPATH:-}"
+fi
+
+job_start="$(date '+%F %T')"
+echo "[$job_start] Job $JOB_LABEL starting on $(hostname)" >&2
+
+failures=0
+line_no=0
+while IFS='|' read -r seed_dir seed_name; do
+    seed_dir=$(strip_cr "$seed_dir")
+    seed_name=$(strip_cr "$seed_name")
+    if [ -z "$seed_dir" ]; then
+        continue
+    fi
+    ((line_no++))
+
+    if [ ! -d "$seed_dir" ]; then
+        echo "Seed directory not found: $seed_dir" >&2
+        failures=1
+        continue
+    fi
+
+    seed_results_dir="$RESULTS_DIR/$seed_name"
+    seed_logs_dir="$LOGS_DIR/$seed_name"
+    log_dir="$seed_logs_dir/$ASSAY_NAME"
+    log_file="$log_dir/${ASSAY_NAME}_${MODEL_NAME}_${FINGERPRINT_NAME}.log"
+    mkdir -p "$seed_results_dir" "$log_dir"
+
+    resolve_seed_paths "$seed_dir"
+    if [ ! -f "$train_csv" ]; then
+        echo "Missing train_df.csv for $seed_dir" | tee -a "$log_file" >&2
+        failures=1
+        continue
+    fi
+
+    save_dir="$seed_results_dir/${ASSAY_NAME}_${MODEL_NAME}_${FINGERPRINT_NAME}"
+    mkdir -p "$save_dir"
+
+    start_ts="$(date '+%F %T')"
+    echo "[$start_ts] START ${seed_name}:${ASSAY_NAME}_${MODEL_NAME}_${FINGERPRINT_NAME}" | tee -a "$log_file"
+    dbg "Running seed_dir=$seed_dir"
+
+    cmd=("$PYTHON_BIN" "$MODEL_DIR/$RUN_SUBDIR/${MODEL_NAME}.py"
+         --fingerprint_type "$FINGERPRINT_NAME"
+         --train_csv "$train_csv" --val_csv "$val_csv" --test_csv "$test_csv"
+         --train_fp_dir "$train_fp_dir" --val_fp_dir "$val_fp_dir" --test_fp_dir "$test_fp_dir"
+         --assay_name "$ASSAY_NAME" --model_save_path "$save_dir")
+    if [ -n "$RANDOM_STATE" ]; then
+        cmd+=(--random_state "$RANDOM_STATE")
+    fi
+
+    set +e
+    "${cmd[@]}" 2>&1 | tee -a "$log_file"
+    exit_code=${PIPESTATUS[0]}
+    set -e
+
+    end_ts="$(date '+%F %T')"
+    if [ "$exit_code" -ne 0 ]; then
+        echo "[$end_ts] END ${seed_name}:${ASSAY_NAME}_${MODEL_NAME}_${FINGERPRINT_NAME} status=$exit_code" | tee -a "$log_file"
+        failures=1
+    else
+        echo "[$end_ts] END ${seed_name}:${ASSAY_NAME}_${MODEL_NAME}_${FINGERPRINT_NAME} status=0" | tee -a "$log_file"
+    fi
+
+done < "$SEED_FILE"
+
+job_end="$(date '+%F %T')"
+if [ "$failures" -ne 0 ]; then
+    echo "[$job_end] Job $JOB_LABEL completed with failures" >&2
+    exit 1
+fi
+
+echo "[$job_end] Job $JOB_LABEL completed successfully" >&2

--- a/slurm/training_config.yaml
+++ b/slurm/training_config.yaml
@@ -1,0 +1,57 @@
+project:
+  # Path to the config.py file that defines VERSION/OBJECT/paths
+  config_path: ../ToxCast_model/config.py
+  # Optional overrides; leave null to use values from config.py
+  base_dir: null
+  data_dir: null
+  logs_dir: null
+  results_dir: null
+  # Seed discovery behaviour
+  seeds:
+    # Provide an explicit ordered list of seed directory names. When empty,
+    # all directories matching ``seed_*`` under ``data_dir`` are used.
+    include: []
+    # Glob pattern used when ``include`` is empty.
+    pattern: "seed_*"
+assays:
+  # Provide an explicit list of assays to train. When empty, the assay names
+  # are inferred from the first seed's training CSV.
+  include: []
+slurm:
+  partitions: [gpu1, gpu2, gpu3, gpu4, gpu5, gpu6]
+  gres: gpu
+  cpus_per_task: 8
+  mem: 16G
+  time: 08:00:00
+  max_jobs: 20
+  throttle:
+    max_queue: 80
+    poll_interval_sec: 30
+logging:
+  # Optional additional directory for slurm stdout/stderr files. Defaults to
+  # ``logs/slurm`` inside the project directory when null.
+  slurm_dir: null
+environment:
+  module:
+    init: /etc/profile.d/modules.sh
+    purge: true
+    load: [cuda/12.1]
+  conda:
+    setup: ~/anaconda3/etc/profile.d/conda.sh
+    env: toxcast_env
+  python: python
+training:
+  models: []
+  fingerprints: []
+  run_subdir: run_v3
+  random_state: null
+  dry_run: false
+  summary:
+    enabled: true
+    script: run_training.sh
+    partition: null
+    gres: null
+    cpus_per_task: null
+    mem: null
+    time: null
+    depends_on_fail: false


### PR DESCRIPTION
## Summary
- add a configurable `training_config.yaml` to control project paths, seeds, resources, and assay/model/fingerprint combinations
- implement `submit_v3_training.py` to read the YAML, throttle queue submissions, submit one job per assay/model/fingerprint, and schedule a summary job
- add `train_combo_worker.sh` to loop through all seeds per job with structured logging and update the README with usage instructions

## Testing
- python -m compileall slurm/submit_v3_training.py

------
https://chatgpt.com/codex/tasks/task_e_68d63d59dcc0832099eee89c9dd20fcc