### PR TITLE
Add GPU-aware Slurm submission utility and CLI switches

### DIFF
--- a/ToxCast_model/run_v3/dt.py
+++ b/ToxCast_model/run_v3/dt.py
@@ -18,7 +18,9 @@ from toxcast_pkg.v3_data import get_assay_names_from_csv
 
 from run_v3.utils import (
     METRIC_KEYS,
+    add_device_arguments,
     apply_smote,
+    configure_device,
     cross_validate_models,
     evaluate_predictions,
     find_best_model,
@@ -43,6 +45,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--assay_index", type=int, default=None, help="Index of the assay column (fallback if name omitted)")
     parser.add_argument("--model_save_path", required=True)
     parser.add_argument("--random_state", type=int, default=42)
+    add_device_arguments(parser)
     return parser.parse_args()
 
 
@@ -61,6 +64,8 @@ def build_model(params: dict, random_state: int) -> DecisionTreeClassifier:
 
 def main() -> None:
     args = parse_args()
+    device = configure_device(args.use_gpu)
+    logging.info("Selected compute device: %s", device)
     fingerprint_type = args.fingerprint_type
     assay_name = resolve_assay_name(args)
 

--- a/ToxCast_model/run_v3/gbt.py
+++ b/ToxCast_model/run_v3/gbt.py
@@ -18,7 +18,9 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from run_v3.utils import (
     METRIC_KEYS,
+    add_device_arguments,
     apply_smote,
+    configure_device,
     cross_validate_models,
     evaluate_predictions,
     find_best_model,
@@ -43,6 +45,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--assay_index", type=int, default=None)
     parser.add_argument("--model_save_path", required=True)
     parser.add_argument("--random_state", type=int, default=42)
+    add_device_arguments(parser)
     return parser.parse_args()
 
 
@@ -61,6 +64,8 @@ def build_model(params: dict, random_state: int) -> GradientBoostingClassifier:
 
 def main() -> None:
     args = parse_args()
+    device = configure_device(args.use_gpu)
+    logging.info("Selected compute device: %s", device)
     fingerprint_type = args.fingerprint_type
     assay_name = resolve_assay_name(args)
 

--- a/ToxCast_model/run_v3/logistic.py
+++ b/ToxCast_model/run_v3/logistic.py
@@ -18,7 +18,9 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from run_v3.utils import (
     METRIC_KEYS,
+    add_device_arguments,
     apply_smote,
+    configure_device,
     cross_validate_models,
     evaluate_predictions,
     find_best_model,
@@ -43,6 +45,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--assay_index", type=int, default=None)
     parser.add_argument("--model_save_path", required=True)
     parser.add_argument("--random_state", type=int, default=42)
+    add_device_arguments(parser)
     return parser.parse_args()
 
 
@@ -61,6 +64,8 @@ def build_model(params: dict, random_state: int) -> LogisticRegression:
 
 def main() -> None:
     args = parse_args()
+    device = configure_device(args.use_gpu)
+    logging.info("Selected compute device: %s", device)
     fingerprint_type = args.fingerprint_type
     assay_name = resolve_assay_name(args)
 

--- a/ToxCast_model/run_v3/rf.py
+++ b/ToxCast_model/run_v3/rf.py
@@ -18,7 +18,9 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from run_v3.utils import (
     METRIC_KEYS,
+    add_device_arguments,
     apply_smote,
+    configure_device,
     cross_validate_models,
     evaluate_predictions,
     find_best_model,
@@ -43,6 +45,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--assay_index", type=int, default=None)
     parser.add_argument("--model_save_path", required=True)
     parser.add_argument("--random_state", type=int, default=42)
+    add_device_arguments(parser)
     return parser.parse_args()
 
 
@@ -61,6 +64,8 @@ def build_model(params: dict, random_state: int) -> RandomForestClassifier:
 
 def main() -> None:
     args = parse_args()
+    device = configure_device(args.use_gpu)
+    logging.info("Selected compute device: %s", device)
     fingerprint_type = args.fingerprint_type
     assay_name = resolve_assay_name(args)
 

--- a/ToxCast_model/run_v3/utils.py
+++ b/ToxCast_model/run_v3/utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import argparse
 import json
 import logging
 from pathlib import Path
@@ -26,6 +27,76 @@ from toxcast_pkg.v3_data import (
 
 
 METRIC_KEYS = ("precision", "recall", "f1", "accuracy", "roc_auc")
+
+
+def add_device_arguments(parser: argparse.ArgumentParser) -> None:
+    """Add common GPU control arguments to ``parser``.
+
+    All run_v3 entrypoints share the same desire for a ``--use-gpu`` flag,
+    while still allowing users to opt out explicitly.  The helper keeps the
+    behaviour consistent across scripts.
+    """
+
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument(
+        "--use-gpu",
+        dest="use_gpu",
+        action="store_true",
+        help="Prefer CUDA devices when available (default: CPU).",
+    )
+    group.add_argument(
+        "--no-gpu",
+        dest="use_gpu",
+        action="store_false",
+        help="Force CPU execution even when CUDA devices are available.",
+    )
+    parser.set_defaults(use_gpu=False)
+
+
+def configure_device(use_gpu: bool, logger: logging.Logger | None = None) -> str:
+    """Initialise the preferred compute device for deep-learning frameworks.
+
+    The helper attempts to configure PyTorch first and falls back to
+    TensorFlow.  Any errors are converted into informative log messages so the
+    caller can keep running on CPU.  The selected device identifier is
+    returned to help with debugging/logging.
+    """
+
+    log = logger or logging.getLogger(__name__)
+    if use_gpu:
+        try:  # PyTorch configuration (optional dependency)
+            import torch
+
+            if torch.cuda.is_available():
+                torch.cuda.set_device(0)
+                device = torch.device("cuda:0")
+                log.info("Using PyTorch device: %s", device)
+                return str(device)
+            log.warning("GPU requested but PyTorch reports no CUDA devices. Falling back to CPU.")
+        except Exception as exc:  # pragma: no cover - optional dependency guard
+            log.warning("GPU requested but PyTorch initialisation failed: %s", exc)
+
+        try:  # TensorFlow configuration (optional dependency)
+            import tensorflow as tf
+
+            gpus = tf.config.list_physical_devices("GPU")
+            if gpus:
+                try:
+                    tf.config.set_visible_devices(gpus[0], "GPU")
+                except Exception as exc:  # pragma: no cover - TF runtime guard
+                    log.warning("Unable to limit TensorFlow to a single GPU: %s", exc)
+                try:  # pragma: no cover - best effort memory growth setting
+                    tf.config.experimental.set_memory_growth(gpus[0], True)
+                except Exception:
+                    pass
+                log.info("Using TensorFlow GPU device: %s", gpus[0].name)
+                return gpus[0].name
+            log.warning("GPU requested but TensorFlow did not detect any GPUs. Falling back to CPU.")
+        except Exception as exc:  # pragma: no cover - optional dependency guard
+            log.warning("TensorFlow GPU initialisation failed: %s", exc)
+
+    log.info("Using CPU execution.")
+    return "cpu"
 
 
 def save_results(result: dict, path: str | Path) -> None:

--- a/ToxCast_model/run_v3/xgb.py
+++ b/ToxCast_model/run_v3/xgb.py
@@ -24,7 +24,9 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from run_v3.utils import (
     METRIC_KEYS,
+    add_device_arguments,
     apply_smote,
+    configure_device,
     cross_validate_models,
     evaluate_predictions,
     find_best_model,
@@ -49,6 +51,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--assay_index", type=int, default=None)
     parser.add_argument("--model_save_path", required=True)
     parser.add_argument("--random_state", type=int, default=42)
+    add_device_arguments(parser)
     return parser.parse_args()
 
 
@@ -67,6 +70,8 @@ def build_model(params: dict, random_state: int) -> XGBClassifier:
 
 def main() -> None:
     args = parse_args()
+    device = configure_device(args.use_gpu)
+    logging.info("Selected compute device: %s", device)
     fingerprint_type = args.fingerprint_type
     assay_name = resolve_assay_name(args)
 

--- a/slurm/gpu_submit.sh
+++ b/slurm/gpu_submit.sh
@@ -1,0 +1,335 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "${SCRIPT_DIR}/.." && pwd)
+JOB_TEMPLATE_PATH="${SCRIPT_DIR}/job_gpu.sbatch"
+LOG_DIR="${REPO_ROOT}/logs/slurm"
+LOG_FILE="${LOG_DIR}/submitter.log"
+
+mkdir -p "${LOG_DIR}"
+
+cleanup_files=()
+
+cleanup() {
+    local status=$?
+    for path in "${cleanup_files[@]:-}"; do
+        if [[ -n "${path}" && -f "${path}" ]]; then
+            rm -f "${path}"
+        fi
+    done
+    if [[ -n "${command_script:-}" && "${command_script_keep}" != true && -f "${command_script}" ]]; then
+        rm -f "${command_script}"
+    fi
+    return ${status}
+}
+
+log_error() {
+    local line="$1"
+    local cmd="$2"
+    log_event "[ERROR] line:${line} cmd:${cmd}"
+}
+
+trap 'log_error $LINENO "$BASH_COMMAND"' ERR
+trap cleanup EXIT
+
+require_cmd() {
+    if ! command -v "$1" >/dev/null 2>&1; then
+        echo "Required command not found: $1" >&2
+        exit 1
+    fi
+}
+
+require_cmd sbatch
+require_cmd squeue
+require_cmd scancel
+require_cmd date
+
+log_event() {
+    local message="$1"
+    local timestamp
+    timestamp="$(date '+%F %T')"
+    printf '[%s] %s\n' "${timestamp}" "${message}" | tee -a "${LOG_FILE}"
+}
+
+usage() {
+    cat <<USAGE
+Usage: $0 [options] -- <command ...>
+
+Options:
+  --job-name NAME           Slurm job name (default: run_v3_gpu)
+  --gpu-count N             Number of GPUs to request (default: 1)
+  --cpus N                  CPUs per task (default: 8)
+  --mem SIZE                Memory request, e.g. 32G (default: 32G)
+  --time LIMIT              Time limit in HH:MM:SS (default: 04:00:00)
+  --seed ID                 Seed identifier for performance logging
+  --assay NAME              Assay name for performance logging
+  --model NAME              Model name for performance logging
+  --mf NAME                 Molecular fingerprint label for performance logging
+  --label TEXT              Custom label recorded in performance log
+  --workdir PATH            Working directory for the job (default: repository root)
+  --compiler-module NAME    Compiler module to load (default: gnu12/12.3.0)
+  --cuda-module NAME        CUDA module to load (default: cuda/12.1.1)
+  --module NAME             Additional module to load (can be repeated)
+  --poll-interval SEC       Polling interval in seconds (default: 2)
+  --poll-timeout SEC        Allocation timeout per partition (default: 60)
+  -h, --help                Show this help message
+
+The command following ``--`` is executed inside the job script. Use
+``--use-gpu`` or ``--no-gpu`` flags within that command to control
+run_v3 entrypoints.
+USAGE
+}
+
+job_name="run_v3_gpu"
+gpu_count=1
+cpus=8
+memory="32G"
+time_limit="04:00:00"
+seed_id=""
+assay_name=""
+model_name=""
+mf_name=""
+command_label=""
+work_dir="${REPO_ROOT}"
+compiler_module="gnu12/12.3.0"
+cuda_module="cuda/12.1.1"
+extra_modules=()
+poll_interval=2
+poll_timeout=60
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --job-name)
+            job_name="$2"; shift 2 ;;
+        --gpu-count)
+            gpu_count="$2"; shift 2 ;;
+        --cpus)
+            cpus="$2"; shift 2 ;;
+        --mem)
+            memory="$2"; shift 2 ;;
+        --time)
+            time_limit="$2"; shift 2 ;;
+        --seed)
+            seed_id="$2"; shift 2 ;;
+        --assay)
+            assay_name="$2"; shift 2 ;;
+        --model)
+            model_name="$2"; shift 2 ;;
+        --mf)
+            mf_name="$2"; shift 2 ;;
+        --label)
+            command_label="$2"; shift 2 ;;
+        --workdir)
+            work_dir="$2"; shift 2 ;;
+        --compiler-module)
+            compiler_module="$2"; shift 2 ;;
+        --cuda-module)
+            cuda_module="$2"; shift 2 ;;
+        --module)
+            extra_modules+=("$2"); shift 2 ;;
+        --poll-interval)
+            poll_interval="$2"; shift 2 ;;
+        --poll-timeout)
+            poll_timeout="$2"; shift 2 ;;
+        -h|--help)
+            usage
+            exit 0 ;;
+        --)
+            shift
+            break ;;
+        *)
+            echo "Unknown option: $1" >&2
+            usage
+            exit 1 ;;
+    esac
+done
+
+if [[ $# -eq 0 ]]; then
+    echo "No command specified." >&2
+    usage
+    exit 1
+fi
+
+if [[ ! -f "${JOB_TEMPLATE_PATH}" ]]; then
+    echo "Template not found: ${JOB_TEMPLATE_PATH}" >&2
+    exit 1
+fi
+
+if [[ "${job_name}" =~ [[:space:]] ]]; then
+    echo "Job name must not contain whitespace." >&2
+    exit 1
+fi
+
+command_script=""
+command_script_keep=false
+
+normalise_export_value() {
+    local name="$1"
+    local value="$2"
+    local sanitised="${value//[[:space:]]/_}"
+    if [[ "${sanitised}" != "${value}" && -n "${value}" ]]; then
+        log_event "Normalised ${name} value '${value}' to '${sanitised}' for environment export"
+    fi
+    printf '%s' "${sanitised}"
+}
+
+seed_id=$(normalise_export_value "seed" "${seed_id}")
+assay_name=$(normalise_export_value "assay" "${assay_name}")
+model_name=$(normalise_export_value "model" "${model_name}")
+mf_name=$(normalise_export_value "mf" "${mf_name}")
+command_label=$(normalise_export_value "label" "${command_label}")
+
+if [[ "${work_dir}" =~ [[:space:]] ]]; then
+    echo "Working directory must not contain whitespace: ${work_dir}" >&2
+    exit 1
+fi
+
+command_script=$(mktemp "${LOG_DIR}/cmd.XXXXXX.sh")
+{
+    printf '#!/usr/bin/env bash\n'
+    printf 'set -euo pipefail\n'
+    printf '%s\n' "$(printf '%q ' "$@" | sed 's/[[:space:]]*$//')"
+} > "${command_script}"
+chmod 700 "${command_script}"
+
+log_event "Command script created at ${command_script}"
+
+prepare_job_script() {
+    local partition="$1"
+    local output_path="$2"
+    TEMPLATE_PATH="${JOB_TEMPLATE_PATH}" \
+    REPL_PARTITION="${partition}" \
+    REPL_GPU_COUNT="${gpu_count}" \
+    REPL_CPUS="${cpus}" \
+    REPL_MEMORY="${memory}" \
+    REPL_TIME_LIMIT="${time_limit}" \
+    REPL_JOB_NAME="${job_name}" \
+    REPL_COMPILER_MODULE="${compiler_module}" \
+    REPL_CUDA_MODULE="${cuda_module}" \
+    REPL_WORK_DIR="${work_dir}" \
+    python - <<'PY'
+import os
+import sys
+from pathlib import Path
+
+template = Path(os.environ["TEMPLATE_PATH"]).read_text()
+replacements = {
+    "__PARTITION__": os.environ["REPL_PARTITION"],
+    "__GPU_COUNT__": os.environ["REPL_GPU_COUNT"],
+    "__CPUS__": os.environ["REPL_CPUS"],
+    "__MEMORY__": os.environ["REPL_MEMORY"],
+    "__TIME_LIMIT__": os.environ["REPL_TIME_LIMIT"],
+    "__JOB_NAME__": os.environ["REPL_JOB_NAME"],
+    "__COMPILER_MODULE__": os.environ["REPL_COMPILER_MODULE"],
+    "__CUDA_MODULE__": os.environ["REPL_CUDA_MODULE"],
+    "__WORK_DIR__": os.environ["REPL_WORK_DIR"],
+}
+content = template
+for key, value in replacements.items():
+    content = content.replace(key, value)
+Path(sys.argv[1]).write_text(content)
+PY
+}
+
+poll_job() {
+    local job_id="$1"
+    local partition="$2"
+    local timeout="$3"
+    local start_ts
+    start_ts=$(date +%s)
+    while true; do
+        local status_line
+        status_line=$(squeue -j "${job_id}" -h -o "%T|%R" 2>/dev/null || true)
+        if [[ -z "${status_line}" ]]; then
+            log_event "Job ${job_id} no longer appears in squeue."
+            return 2
+        fi
+        local state reason
+        IFS='|' read -r state reason <<< "${status_line}"
+        log_event "Job ${job_id} poll: state=${state} reason=${reason}"
+        if [[ -n "${reason}" && "${reason}" != \(* ]]; then
+            log_event "Job ${job_id} allocated on ${reason}"
+            return 0
+        fi
+        if (( timeout > 0 )); then
+            local now elapsed
+            now=$(date +%s)
+            elapsed=$(( now - start_ts ))
+            if (( elapsed >= timeout )); then
+                log_event "Job ${job_id} timed out on partition ${partition}"
+                return 1
+            fi
+        fi
+        sleep "${poll_interval}"
+    done
+}
+
+submit_to_partition() {
+    local partition="$1"
+    local timeout="$2"
+    local job_script
+    job_script=$(mktemp "${REPO_ROOT}/.gpu_job.XXXXXX")
+    cleanup_files+=("${job_script}")
+    prepare_job_script "${partition}" "${job_script}"
+
+    local extra_modules_joined=""
+    if [[ ${#extra_modules[@]} -gt 0 ]]; then
+        extra_modules_joined=$(IFS=','; echo "${extra_modules[*]}")
+    fi
+
+    local export_vars="ALL,COMMAND_FILE=${command_script},WORK_DIR=${work_dir},SEED_ID=${seed_id},ASSAY_NAME=${assay_name},MODEL_NAME=${model_name},MF_NAME=${mf_name},PERF_LOG_LABEL=${command_label},EXTRA_MODULES=${extra_modules_joined}"
+
+    log_event "Submitting job to partition ${partition}"
+    local job_id
+    if ! job_id=$(sbatch --parsable --export="${export_vars}" "${job_script}"); then
+        log_event "Failed to submit job to ${partition}"
+        return 1
+    fi
+    log_event "Submitted job ${job_id} to ${partition}"
+
+    local poll_result
+    poll_job "${job_id}" "${partition}" "${timeout}"
+    poll_result=$?
+    case "${poll_result}" in
+        0)
+            log_event "Job ${job_id} successfully allocated on ${partition}"
+            echo "${job_id}"
+            return 0 ;;
+        1)
+            log_event "Cancelling job ${job_id} on ${partition} after timeout"
+            scancel "${job_id}" >/dev/null 2>&1 || true
+            return 1 ;;
+        *)
+            log_event "Job ${job_id} ended before allocation on ${partition}"
+            return 1 ;;
+    esac
+}
+
+partitions=(gpu1 gpu6 gpu2 gpu3 gpu4 gpu5)
+job_allocated=""
+
+for partition in "${partitions[@]}"; do
+    if job_id=$(submit_to_partition "${partition}" "${poll_timeout}"); then
+        job_allocated="${job_id}"
+        command_script_keep=true
+        break
+    fi
+    log_event "Partition ${partition} attempt finished without allocation."
+    sleep 1
+done
+
+if [[ -z "${job_allocated}" ]]; then
+    log_event "No allocation after full rotation. Submitting to gpu1 with indefinite wait."
+    if job_id=$(submit_to_partition "gpu1" 0); then
+        job_allocated="${job_id}"
+        command_script_keep=true
+    else
+        log_event "Submission to gpu1 failed during indefinite wait."
+        exit 1
+    fi
+fi
+
+log_event "Final allocated job ID: ${job_allocated}"
+exit 0

--- a/slurm/job_gpu.sbatch
+++ b/slurm/job_gpu.sbatch
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+#SBATCH --job-name=__JOB_NAME__
+#SBATCH --partition=__PARTITION__
+#SBATCH --gres=gpu:__GPU_COUNT__
+#SBATCH --cpus-per-task=__CPUS__
+#SBATCH --mem=__MEMORY__
+#SBATCH --time=__TIME_LIMIT__
+#SBATCH -e logs/slurm/%x_%j.err
+#SBATCH -o logs/slurm/%x_%j.out
+
+set -euo pipefail
+set -o pipefail
+
+trap 'echo "[ERROR] line:${LINENO} cmd:${BASH_COMMAND}" >&2' ERR
+
+cleanup() {
+    if [[ -n "${__JOB_TMP_SCRIPT:-}" && -f "${__JOB_TMP_SCRIPT}" ]]; then
+        rm -f "${__JOB_TMP_SCRIPT}"
+    fi
+}
+trap cleanup EXIT
+
+if [[ -n "${WORK_DIR:-}" ]]; then
+    if [[ ! -d "${WORK_DIR}" ]]; then
+        echo "Work directory not found: ${WORK_DIR}" >&2
+        exit 1
+    fi
+    cd "${WORK_DIR}"
+fi
+
+mkdir -p logs/slurm
+
+if command -v module >/dev/null 2>&1; then
+    module purge || true
+    module load __COMPILER_MODULE__
+    module load __CUDA_MODULE__
+    if [[ -n "${EXTRA_MODULES:-}" ]]; then
+        IFS=',' read -r -a __extra_mods <<< "${EXTRA_MODULES}"
+        for __mod in "${__extra_mods[@]}"; do
+            if [[ -n "${__mod}" ]]; then
+                module load "${__mod}"
+            fi
+        done
+    fi
+fi
+
+if [[ -z "${COMMAND_FILE:-}" ]]; then
+    echo "COMMAND_FILE is empty; aborting." >&2
+    exit 1
+fi
+
+if [[ ! -f "${COMMAND_FILE}" ]]; then
+    echo "Command file not found: ${COMMAND_FILE}" >&2
+    exit 1
+fi
+
+if [[ ! -x "${COMMAND_FILE}" ]]; then
+    chmod +x "${COMMAND_FILE}" 2>/dev/null || true
+fi
+
+__JOB_TMP_SCRIPT="${COMMAND_FILE}"
+
+sanitise_component() {
+    local value="$1"
+    value=${value//[^A-Za-z0-9_.-]/_}
+    printf '%s' "${value}"
+}
+
+if [[ -n "${SEED_ID:-}" && -n "${ASSAY_NAME:-}" && -n "${MODEL_NAME:-}" && -n "${MF_NAME:-}" ]]; then
+    seed_component=$(sanitise_component "${SEED_ID}")
+    assay_component=$(sanitise_component "${ASSAY_NAME}")
+    model_component=$(sanitise_component "${MODEL_NAME}")
+    mf_component=$(sanitise_component "${MF_NAME}")
+    perf_dir="logs/seed_${seed_component}"
+    perf_log="${perf_dir}/${seed_component}_${assay_component}_${model_component}_${mf_component}.log"
+else
+    perf_dir="logs/perf"
+    mkdir -p "${perf_dir}"
+    perf_log="${perf_dir}/${SLURM_JOB_ID}.log"
+fi
+mkdir -p "$(dirname "${perf_log}")"
+
+echo "[$(date '+%F %T')] Job ${SLURM_JOB_ID} starting on $(hostname)" | tee -a "${perf_log}" >&2
+if [[ -n "${PERF_LOG_LABEL:-}" ]]; then
+    echo "[$(date '+%F %T')] Label: ${PERF_LOG_LABEL}" | tee -a "${perf_log}" >&2
+fi
+
+if [[ -n "${perf_log}" ]]; then
+    {
+        "${COMMAND_FILE}"
+    } 2> >(tee -a "${perf_log}" >&2) | tee -a "${perf_log}"
+    command_status=${PIPESTATUS[0]}
+else
+    "${COMMAND_FILE}"
+    command_status=$?
+fi
+
+end_ts="$(date '+%F %T')"
+echo "[${end_ts}] Command finished with status ${command_status}" | tee -a "${perf_log}" >&2
+
+exit ${command_status}


### PR DESCRIPTION
## Summary
- add a GPU submission helper that rotates across GPU partitions, logs every state transition, and falls back to indefinite waiting on gpu1
- introduce a reusable sbatch template that loads compiler/CUDA modules, sanitises log filenames, and tees command output into the per-seed performance logs
- provide shared GPU selection helpers and wire them into each run_v3 training entrypoint so users can toggle between CUDA and CPU execution

## Testing
- python -m compileall ToxCast_model/run_v3
- bash -n slurm/gpu_submit.sh
- bash -n slurm/job_gpu.sbatch

------
https://chatgpt.com/codex/tasks/task_e_68da2fe6e5a88320a72698791187fa5c