### PR TITLE
Route v3 training submissions through GPU helper

### DIFF
--- a/ToxCast_model/run_v3/dt.py
+++ b/ToxCast_model/run_v3/dt.py
@@ -18,7 +18,9 @@ from toxcast_pkg.v3_data import get_assay_names_from_csv
 
 from run_v3.utils import (
     METRIC_KEYS,
+    add_device_arguments,
     apply_smote,
+    configure_device,
     cross_validate_models,
     evaluate_predictions,
     find_best_model,
@@ -43,6 +45,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--assay_index", type=int, default=None, help="Index of the assay column (fallback if name omitted)")
     parser.add_argument("--model_save_path", required=True)
     parser.add_argument("--random_state", type=int, default=42)
+    add_device_arguments(parser)
     return parser.parse_args()
 
 
@@ -61,6 +64,8 @@ def build_model(params: dict, random_state: int) -> DecisionTreeClassifier:
 
 def main() -> None:
     args = parse_args()
+    device = configure_device(args.use_gpu)
+    logging.info("Selected compute device: %s", device)
     fingerprint_type = args.fingerprint_type
     assay_name = resolve_assay_name(args)
 

--- a/ToxCast_model/run_v3/gbt.py
+++ b/ToxCast_model/run_v3/gbt.py
@@ -18,7 +18,9 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from run_v3.utils import (
     METRIC_KEYS,
+    add_device_arguments,
     apply_smote,
+    configure_device,
     cross_validate_models,
     evaluate_predictions,
     find_best_model,
@@ -43,6 +45,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--assay_index", type=int, default=None)
     parser.add_argument("--model_save_path", required=True)
     parser.add_argument("--random_state", type=int, default=42)
+    add_device_arguments(parser)
     return parser.parse_args()
 
 
@@ -61,6 +64,8 @@ def build_model(params: dict, random_state: int) -> GradientBoostingClassifier:
 
 def main() -> None:
     args = parse_args()
+    device = configure_device(args.use_gpu)
+    logging.info("Selected compute device: %s", device)
     fingerprint_type = args.fingerprint_type
     assay_name = resolve_assay_name(args)
 

--- a/ToxCast_model/run_v3/logistic.py
+++ b/ToxCast_model/run_v3/logistic.py
@@ -18,7 +18,9 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from run_v3.utils import (
     METRIC_KEYS,
+    add_device_arguments,
     apply_smote,
+    configure_device,
     cross_validate_models,
     evaluate_predictions,
     find_best_model,
@@ -43,6 +45,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--assay_index", type=int, default=None)
     parser.add_argument("--model_save_path", required=True)
     parser.add_argument("--random_state", type=int, default=42)
+    add_device_arguments(parser)
     return parser.parse_args()
 
 
@@ -61,6 +64,8 @@ def build_model(params: dict, random_state: int) -> LogisticRegression:
 
 def main() -> None:
     args = parse_args()
+    device = configure_device(args.use_gpu)
+    logging.info("Selected compute device: %s", device)
     fingerprint_type = args.fingerprint_type
     assay_name = resolve_assay_name(args)
 

--- a/ToxCast_model/run_v3/rf.py
+++ b/ToxCast_model/run_v3/rf.py
@@ -18,7 +18,9 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from run_v3.utils import (
     METRIC_KEYS,
+    add_device_arguments,
     apply_smote,
+    configure_device,
     cross_validate_models,
     evaluate_predictions,
     find_best_model,
@@ -43,6 +45,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--assay_index", type=int, default=None)
     parser.add_argument("--model_save_path", required=True)
     parser.add_argument("--random_state", type=int, default=42)
+    add_device_arguments(parser)
     return parser.parse_args()
 
 
@@ -61,6 +64,8 @@ def build_model(params: dict, random_state: int) -> RandomForestClassifier:
 
 def main() -> None:
     args = parse_args()
+    device = configure_device(args.use_gpu)
+    logging.info("Selected compute device: %s", device)
     fingerprint_type = args.fingerprint_type
     assay_name = resolve_assay_name(args)
 

--- a/ToxCast_model/run_v3/utils.py
+++ b/ToxCast_model/run_v3/utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import argparse
 import json
 import logging
 from pathlib import Path
@@ -26,6 +27,76 @@ from toxcast_pkg.v3_data import (
 
 
 METRIC_KEYS = ("precision", "recall", "f1", "accuracy", "roc_auc")
+
+
+def add_device_arguments(parser: argparse.ArgumentParser) -> None:
+    """Add common GPU control arguments to ``parser``.
+
+    All run_v3 entrypoints share the same desire for a ``--use-gpu`` flag,
+    while still allowing users to opt out explicitly.  The helper keeps the
+    behaviour consistent across scripts.
+    """
+
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument(
+        "--use-gpu",
+        dest="use_gpu",
+        action="store_true",
+        help="Prefer CUDA devices when available (default: CPU).",
+    )
+    group.add_argument(
+        "--no-gpu",
+        dest="use_gpu",
+        action="store_false",
+        help="Force CPU execution even when CUDA devices are available.",
+    )
+    parser.set_defaults(use_gpu=False)
+
+
+def configure_device(use_gpu: bool, logger: logging.Logger | None = None) -> str:
+    """Initialise the preferred compute device for deep-learning frameworks.
+
+    The helper attempts to configure PyTorch first and falls back to
+    TensorFlow.  Any errors are converted into informative log messages so the
+    caller can keep running on CPU.  The selected device identifier is
+    returned to help with debugging/logging.
+    """
+
+    log = logger or logging.getLogger(__name__)
+    if use_gpu:
+        try:  # PyTorch configuration (optional dependency)
+            import torch
+
+            if torch.cuda.is_available():
+                torch.cuda.set_device(0)
+                device = torch.device("cuda:0")
+                log.info("Using PyTorch device: %s", device)
+                return str(device)
+            log.warning("GPU requested but PyTorch reports no CUDA devices. Falling back to CPU.")
+        except Exception as exc:  # pragma: no cover - optional dependency guard
+            log.warning("GPU requested but PyTorch initialisation failed: %s", exc)
+
+        try:  # TensorFlow configuration (optional dependency)
+            import tensorflow as tf
+
+            gpus = tf.config.list_physical_devices("GPU")
+            if gpus:
+                try:
+                    tf.config.set_visible_devices(gpus[0], "GPU")
+                except Exception as exc:  # pragma: no cover - TF runtime guard
+                    log.warning("Unable to limit TensorFlow to a single GPU: %s", exc)
+                try:  # pragma: no cover - best effort memory growth setting
+                    tf.config.experimental.set_memory_growth(gpus[0], True)
+                except Exception:
+                    pass
+                log.info("Using TensorFlow GPU device: %s", gpus[0].name)
+                return gpus[0].name
+            log.warning("GPU requested but TensorFlow did not detect any GPUs. Falling back to CPU.")
+        except Exception as exc:  # pragma: no cover - optional dependency guard
+            log.warning("TensorFlow GPU initialisation failed: %s", exc)
+
+    log.info("Using CPU execution.")
+    return "cpu"
 
 
 def save_results(result: dict, path: str | Path) -> None:

--- a/ToxCast_model/run_v3/xgb.py
+++ b/ToxCast_model/run_v3/xgb.py
@@ -24,7 +24,9 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from run_v3.utils import (
     METRIC_KEYS,
+    add_device_arguments,
     apply_smote,
+    configure_device,
     cross_validate_models,
     evaluate_predictions,
     find_best_model,
@@ -49,6 +51,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--assay_index", type=int, default=None)
     parser.add_argument("--model_save_path", required=True)
     parser.add_argument("--random_state", type=int, default=42)
+    add_device_arguments(parser)
     return parser.parse_args()
 
 
@@ -67,6 +70,8 @@ def build_model(params: dict, random_state: int) -> XGBClassifier:
 
 def main() -> None:
     args = parse_args()
+    device = configure_device(args.use_gpu)
+    logging.info("Selected compute device: %s", device)
     fingerprint_type = args.fingerprint_type
     assay_name = resolve_assay_name(args)
 

--- a/slurm/gpu_submit.sh
+++ b/slurm/gpu_submit.sh
@@ -1,0 +1,335 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "${SCRIPT_DIR}/.." && pwd)
+JOB_TEMPLATE_PATH="${SCRIPT_DIR}/job_gpu.sbatch"
+LOG_DIR="${REPO_ROOT}/logs/slurm"
+LOG_FILE="${LOG_DIR}/submitter.log"
+
+mkdir -p "${LOG_DIR}"
+
+cleanup_files=()
+
+cleanup() {
+    local status=$?
+    for path in "${cleanup_files[@]:-}"; do
+        if [[ -n "${path}" && -f "${path}" ]]; then
+            rm -f "${path}"
+        fi
+    done
+    if [[ -n "${command_script:-}" && "${command_script_keep}" != true && -f "${command_script}" ]]; then
+        rm -f "${command_script}"
+    fi
+    return ${status}
+}
+
+log_error() {
+    local line="$1"
+    local cmd="$2"
+    log_event "[ERROR] line:${line} cmd:${cmd}"
+}
+
+trap 'log_error $LINENO "$BASH_COMMAND"' ERR
+trap cleanup EXIT
+
+require_cmd() {
+    if ! command -v "$1" >/dev/null 2>&1; then
+        echo "Required command not found: $1" >&2
+        exit 1
+    fi
+}
+
+require_cmd sbatch
+require_cmd squeue
+require_cmd scancel
+require_cmd date
+
+log_event() {
+    local message="$1"
+    local timestamp
+    timestamp="$(date '+%F %T')"
+    printf '[%s] %s\n' "${timestamp}" "${message}" | tee -a "${LOG_FILE}"
+}
+
+usage() {
+    cat <<USAGE
+Usage: $0 [options] -- <command ...>
+
+Options:
+  --job-name NAME           Slurm job name (default: run_v3_gpu)
+  --gpu-count N             Number of GPUs to request (default: 1)
+  --cpus N                  CPUs per task (default: 8)
+  --mem SIZE                Memory request, e.g. 32G (default: 32G)
+  --time LIMIT              Time limit in HH:MM:SS (default: 04:00:00)
+  --seed ID                 Seed identifier for performance logging
+  --assay NAME              Assay name for performance logging
+  --model NAME              Model name for performance logging
+  --mf NAME                 Molecular fingerprint label for performance logging
+  --label TEXT              Custom label recorded in performance log
+  --workdir PATH            Working directory for the job (default: repository root)
+  --compiler-module NAME    Compiler module to load (default: gnu12/12.3.0)
+  --cuda-module NAME        CUDA module to load (default: cuda/12.1.1)
+  --module NAME             Additional module to load (can be repeated)
+  --poll-interval SEC       Polling interval in seconds (default: 2)
+  --poll-timeout SEC        Allocation timeout per partition (default: 60)
+  -h, --help                Show this help message
+
+The command following ``--`` is executed inside the job script. Use
+``--use-gpu`` or ``--no-gpu`` flags within that command to control
+run_v3 entrypoints.
+USAGE
+}
+
+job_name="run_v3_gpu"
+gpu_count=1
+cpus=8
+memory="32G"
+time_limit="04:00:00"
+seed_id=""
+assay_name=""
+model_name=""
+mf_name=""
+command_label=""
+work_dir="${REPO_ROOT}"
+compiler_module="gnu12/12.3.0"
+cuda_module="cuda/12.1.1"
+extra_modules=()
+poll_interval=2
+poll_timeout=60
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --job-name)
+            job_name="$2"; shift 2 ;;
+        --gpu-count)
+            gpu_count="$2"; shift 2 ;;
+        --cpus)
+            cpus="$2"; shift 2 ;;
+        --mem)
+            memory="$2"; shift 2 ;;
+        --time)
+            time_limit="$2"; shift 2 ;;
+        --seed)
+            seed_id="$2"; shift 2 ;;
+        --assay)
+            assay_name="$2"; shift 2 ;;
+        --model)
+            model_name="$2"; shift 2 ;;
+        --mf)
+            mf_name="$2"; shift 2 ;;
+        --label)
+            command_label="$2"; shift 2 ;;
+        --workdir)
+            work_dir="$2"; shift 2 ;;
+        --compiler-module)
+            compiler_module="$2"; shift 2 ;;
+        --cuda-module)
+            cuda_module="$2"; shift 2 ;;
+        --module)
+            extra_modules+=("$2"); shift 2 ;;
+        --poll-interval)
+            poll_interval="$2"; shift 2 ;;
+        --poll-timeout)
+            poll_timeout="$2"; shift 2 ;;
+        -h|--help)
+            usage
+            exit 0 ;;
+        --)
+            shift
+            break ;;
+        *)
+            echo "Unknown option: $1" >&2
+            usage
+            exit 1 ;;
+    esac
+done
+
+if [[ $# -eq 0 ]]; then
+    echo "No command specified." >&2
+    usage
+    exit 1
+fi
+
+if [[ ! -f "${JOB_TEMPLATE_PATH}" ]]; then
+    echo "Template not found: ${JOB_TEMPLATE_PATH}" >&2
+    exit 1
+fi
+
+if [[ "${job_name}" =~ [[:space:]] ]]; then
+    echo "Job name must not contain whitespace." >&2
+    exit 1
+fi
+
+command_script=""
+command_script_keep=false
+
+normalise_export_value() {
+    local name="$1"
+    local value="$2"
+    local sanitised="${value//[[:space:]]/_}"
+    if [[ "${sanitised}" != "${value}" && -n "${value}" ]]; then
+        log_event "Normalised ${name} value '${value}' to '${sanitised}' for environment export"
+    fi
+    printf '%s' "${sanitised}"
+}
+
+seed_id=$(normalise_export_value "seed" "${seed_id}")
+assay_name=$(normalise_export_value "assay" "${assay_name}")
+model_name=$(normalise_export_value "model" "${model_name}")
+mf_name=$(normalise_export_value "mf" "${mf_name}")
+command_label=$(normalise_export_value "label" "${command_label}")
+
+if [[ "${work_dir}" =~ [[:space:]] ]]; then
+    echo "Working directory must not contain whitespace: ${work_dir}" >&2
+    exit 1
+fi
+
+command_script=$(mktemp "${LOG_DIR}/cmd.XXXXXX.sh")
+{
+    printf '#!/usr/bin/env bash\n'
+    printf 'set -euo pipefail\n'
+    printf '%s\n' "$(printf '%q ' "$@" | sed 's/[[:space:]]*$//')"
+} > "${command_script}"
+chmod 700 "${command_script}"
+
+log_event "Command script created at ${command_script}"
+
+prepare_job_script() {
+    local partition="$1"
+    local output_path="$2"
+    TEMPLATE_PATH="${JOB_TEMPLATE_PATH}" \
+    REPL_PARTITION="${partition}" \
+    REPL_GPU_COUNT="${gpu_count}" \
+    REPL_CPUS="${cpus}" \
+    REPL_MEMORY="${memory}" \
+    REPL_TIME_LIMIT="${time_limit}" \
+    REPL_JOB_NAME="${job_name}" \
+    REPL_COMPILER_MODULE="${compiler_module}" \
+    REPL_CUDA_MODULE="${cuda_module}" \
+    REPL_WORK_DIR="${work_dir}" \
+    python - <<'PY'
+import os
+import sys
+from pathlib import Path
+
+template = Path(os.environ["TEMPLATE_PATH"]).read_text()
+replacements = {
+    "__PARTITION__": os.environ["REPL_PARTITION"],
+    "__GPU_COUNT__": os.environ["REPL_GPU_COUNT"],
+    "__CPUS__": os.environ["REPL_CPUS"],
+    "__MEMORY__": os.environ["REPL_MEMORY"],
+    "__TIME_LIMIT__": os.environ["REPL_TIME_LIMIT"],
+    "__JOB_NAME__": os.environ["REPL_JOB_NAME"],
+    "__COMPILER_MODULE__": os.environ["REPL_COMPILER_MODULE"],
+    "__CUDA_MODULE__": os.environ["REPL_CUDA_MODULE"],
+    "__WORK_DIR__": os.environ["REPL_WORK_DIR"],
+}
+content = template
+for key, value in replacements.items():
+    content = content.replace(key, value)
+Path(sys.argv[1]).write_text(content)
+PY
+}
+
+poll_job() {
+    local job_id="$1"
+    local partition="$2"
+    local timeout="$3"
+    local start_ts
+    start_ts=$(date +%s)
+    while true; do
+        local status_line
+        status_line=$(squeue -j "${job_id}" -h -o "%T|%R" 2>/dev/null || true)
+        if [[ -z "${status_line}" ]]; then
+            log_event "Job ${job_id} no longer appears in squeue."
+            return 2
+        fi
+        local state reason
+        IFS='|' read -r state reason <<< "${status_line}"
+        log_event "Job ${job_id} poll: state=${state} reason=${reason}"
+        if [[ -n "${reason}" && "${reason}" != \(* ]]; then
+            log_event "Job ${job_id} allocated on ${reason}"
+            return 0
+        fi
+        if (( timeout > 0 )); then
+            local now elapsed
+            now=$(date +%s)
+            elapsed=$(( now - start_ts ))
+            if (( elapsed >= timeout )); then
+                log_event "Job ${job_id} timed out on partition ${partition}"
+                return 1
+            fi
+        fi
+        sleep "${poll_interval}"
+    done
+}
+
+submit_to_partition() {
+    local partition="$1"
+    local timeout="$2"
+    local job_script
+    job_script=$(mktemp "${REPO_ROOT}/.gpu_job.XXXXXX")
+    cleanup_files+=("${job_script}")
+    prepare_job_script "${partition}" "${job_script}"
+
+    local extra_modules_joined=""
+    if [[ ${#extra_modules[@]} -gt 0 ]]; then
+        extra_modules_joined=$(IFS=','; echo "${extra_modules[*]}")
+    fi
+
+    local export_vars="ALL,COMMAND_FILE=${command_script},WORK_DIR=${work_dir},SEED_ID=${seed_id},ASSAY_NAME=${assay_name},MODEL_NAME=${model_name},MF_NAME=${mf_name},PERF_LOG_LABEL=${command_label},EXTRA_MODULES=${extra_modules_joined}"
+
+    log_event "Submitting job to partition ${partition}"
+    local job_id
+    if ! job_id=$(sbatch --parsable --export="${export_vars}" "${job_script}"); then
+        log_event "Failed to submit job to ${partition}"
+        return 1
+    fi
+    log_event "Submitted job ${job_id} to ${partition}"
+
+    local poll_result
+    poll_job "${job_id}" "${partition}" "${timeout}"
+    poll_result=$?
+    case "${poll_result}" in
+        0)
+            log_event "Job ${job_id} successfully allocated on ${partition}"
+            echo "${job_id}"
+            return 0 ;;
+        1)
+            log_event "Cancelling job ${job_id} on ${partition} after timeout"
+            scancel "${job_id}" >/dev/null 2>&1 || true
+            return 1 ;;
+        *)
+            log_event "Job ${job_id} ended before allocation on ${partition}"
+            return 1 ;;
+    esac
+}
+
+partitions=(gpu1 gpu6 gpu2 gpu3 gpu4 gpu5)
+job_allocated=""
+
+for partition in "${partitions[@]}"; do
+    if job_id=$(submit_to_partition "${partition}" "${poll_timeout}"); then
+        job_allocated="${job_id}"
+        command_script_keep=true
+        break
+    fi
+    log_event "Partition ${partition} attempt finished without allocation."
+    sleep 1
+done
+
+if [[ -z "${job_allocated}" ]]; then
+    log_event "No allocation after full rotation. Submitting to gpu1 with indefinite wait."
+    if job_id=$(submit_to_partition "gpu1" 0); then
+        job_allocated="${job_id}"
+        command_script_keep=true
+    else
+        log_event "Submission to gpu1 failed during indefinite wait."
+        exit 1
+    fi
+fi
+
+log_event "Final allocated job ID: ${job_allocated}"
+exit 0

--- a/slurm/job_gpu.sbatch
+++ b/slurm/job_gpu.sbatch
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+#SBATCH --job-name=__JOB_NAME__
+#SBATCH --partition=__PARTITION__
+#SBATCH --gres=gpu:__GPU_COUNT__
+#SBATCH --cpus-per-task=__CPUS__
+#SBATCH --mem=__MEMORY__
+#SBATCH --time=__TIME_LIMIT__
+#SBATCH -e logs/slurm/%x_%j.err
+#SBATCH -o logs/slurm/%x_%j.out
+
+set -euo pipefail
+set -o pipefail
+
+trap 'echo "[ERROR] line:${LINENO} cmd:${BASH_COMMAND}" >&2' ERR
+
+cleanup() {
+    if [[ -n "${__JOB_TMP_SCRIPT:-}" && -f "${__JOB_TMP_SCRIPT}" ]]; then
+        rm -f "${__JOB_TMP_SCRIPT}"
+    fi
+}
+trap cleanup EXIT
+
+if [[ -n "${WORK_DIR:-}" ]]; then
+    if [[ ! -d "${WORK_DIR}" ]]; then
+        echo "Work directory not found: ${WORK_DIR}" >&2
+        exit 1
+    fi
+    cd "${WORK_DIR}"
+fi
+
+mkdir -p logs/slurm
+
+if command -v module >/dev/null 2>&1; then
+    module purge || true
+    module load __COMPILER_MODULE__
+    module load __CUDA_MODULE__
+    if [[ -n "${EXTRA_MODULES:-}" ]]; then
+        IFS=',' read -r -a __extra_mods <<< "${EXTRA_MODULES}"
+        for __mod in "${__extra_mods[@]}"; do
+            if [[ -n "${__mod}" ]]; then
+                module load "${__mod}"
+            fi
+        done
+    fi
+fi
+
+if [[ -z "${COMMAND_FILE:-}" ]]; then
+    echo "COMMAND_FILE is empty; aborting." >&2
+    exit 1
+fi
+
+if [[ ! -f "${COMMAND_FILE}" ]]; then
+    echo "Command file not found: ${COMMAND_FILE}" >&2
+    exit 1
+fi
+
+if [[ ! -x "${COMMAND_FILE}" ]]; then
+    chmod +x "${COMMAND_FILE}" 2>/dev/null || true
+fi
+
+__JOB_TMP_SCRIPT="${COMMAND_FILE}"
+
+sanitise_component() {
+    local value="$1"
+    value=${value//[^A-Za-z0-9_.-]/_}
+    printf '%s' "${value}"
+}
+
+if [[ -n "${SEED_ID:-}" && -n "${ASSAY_NAME:-}" && -n "${MODEL_NAME:-}" && -n "${MF_NAME:-}" ]]; then
+    seed_component=$(sanitise_component "${SEED_ID}")
+    assay_component=$(sanitise_component "${ASSAY_NAME}")
+    model_component=$(sanitise_component "${MODEL_NAME}")
+    mf_component=$(sanitise_component "${MF_NAME}")
+    perf_dir="logs/seed_${seed_component}"
+    perf_log="${perf_dir}/${seed_component}_${assay_component}_${model_component}_${mf_component}.log"
+else
+    perf_dir="logs/perf"
+    mkdir -p "${perf_dir}"
+    perf_log="${perf_dir}/${SLURM_JOB_ID}.log"
+fi
+mkdir -p "$(dirname "${perf_log}")"
+
+echo "[$(date '+%F %T')] Job ${SLURM_JOB_ID} starting on $(hostname)" | tee -a "${perf_log}" >&2
+if [[ -n "${PERF_LOG_LABEL:-}" ]]; then
+    echo "[$(date '+%F %T')] Label: ${PERF_LOG_LABEL}" | tee -a "${perf_log}" >&2
+fi
+
+if [[ -n "${perf_log}" ]]; then
+    {
+        "${COMMAND_FILE}"
+    } 2> >(tee -a "${perf_log}" >&2) | tee -a "${perf_log}"
+    command_status=${PIPESTATUS[0]}
+else
+    "${COMMAND_FILE}"
+    command_status=$?
+fi
+
+end_ts="$(date '+%F %T')"
+echo "[${end_ts}] Command finished with status ${command_status}" | tee -a "${perf_log}" >&2
+
+exit ${command_status}

--- a/slurm/submit_v3_training.py
+++ b/slurm/submit_v3_training.py
@@ -38,6 +38,21 @@ class Combo:
         return f"{self.assay}_{self.model}_{self.fingerprint}"
 
 
+@dataclasses.dataclass
+class GpuSubmitContext:
+    script: Path
+    work_dir: Path
+    gpu_count: int | None
+    cpus: int | None
+    memory: str | None
+    time_limit: str | None
+    compiler_module: str
+    cuda_module: str
+    extra_modules: tuple[str, ...]
+    poll_interval: int | None
+    poll_timeout: int | None
+
+
 class SubmissionError(RuntimeError):
     pass
 
@@ -136,6 +151,76 @@ def write_seed_file(seeds: Iterable[SeedEntry], path: Path) -> None:
             fh.write(f"{seed.path}|{seed.name}\n")
 
 
+def normalise_bool(value, default: bool) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if isinstance(value, str):
+        val = value.strip().lower()
+        if val in {"1", "true", "yes", "on"}:
+            return True
+        if val in {"0", "false", "no", "off"}:
+            return False
+    return default
+
+
+def coerce_optional_int(value, name: str) -> int | None:
+    if value is None or value == "":
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError) as exc:
+        raise SubmissionError(f"Invalid integer for {name}: {value!r}") from exc
+
+
+def parse_gpu_count(gres: str | None) -> int | None:
+    if not gres:
+        return None
+    match = re.search(r"gpu(?::[^:]+)?(?::(\d+))?", gres)
+    if not match:
+        return None
+    count = match.group(1)
+    if not count:
+        return 1
+    try:
+        value = int(count)
+    except ValueError:
+        return None
+    return value if value > 0 else None
+
+
+def normalise_module_config(module_cfg: dict) -> tuple[str, str, tuple[str, ...]]:
+    loads = module_cfg.get("load") or []
+    compiler = module_cfg.get("compiler") or module_cfg.get("compiler_module")
+    if not compiler:
+        for mod in loads:
+            mod_l = mod.lower()
+            if mod_l.startswith("gnu") or mod_l.startswith("gcc"):
+                compiler = mod
+                break
+    if not compiler:
+        compiler = "gnu12/12.3.0"
+
+    cuda = module_cfg.get("cuda") or module_cfg.get("cuda_module")
+    if not cuda:
+        for mod in loads:
+            if "cuda" in mod.lower():
+                cuda = mod
+                break
+    if not cuda:
+        cuda = "cuda/12.1.1"
+
+    extra = module_cfg.get("extra")
+    if extra is None:
+        extra_list = [mod for mod in loads if mod not in {compiler, cuda}]
+    else:
+        extra_list = list(extra)
+    return compiler, cuda, tuple(extra_list)
+
+
 # =========================
 # Throttle helpers
 # =========================
@@ -193,63 +278,84 @@ def submit_job_once(
     worker_script: Path,
     combo: Combo,
     env: dict,
-    slurm_cfg: dict,
-    log_dir: Path,
+    gpu_ctx: GpuSubmitContext,
 ) -> tuple[str | None, bool, str]:
     """
-    한 번(한 파티션) sbatch 시도.
+    gpu_submit.sh를 통해 한 번 제출 시도.
     return: (job_id or None, submit_limit_hit, failure_reason)
     """
-    export_parts = ["ALL"]
-    for key, value in env.items():
-        export_parts.append(f"{key}={value}")
-    export_arg = ",".join(export_parts)
 
-    gres = slurm_cfg.get("gres")
-    cpus = slurm_cfg.get("cpus_per_task")
-    mem = slurm_cfg.get("mem")
-    time_limit = slurm_cfg.get("time")
-    partition = (slurm_cfg.get("partitions") or [None])[0]  # submit-limit 시 불필요한 파티션 순회 방지
+    if not gpu_ctx.script.exists():
+        raise SubmissionError(f"GPU submit script not found: {gpu_ctx.script}")
 
     job_name = sanitise_job_name(env.get("JOB_LABEL", combo.label))
-    stdout_path = log_dir / f"{job_name}_%j.out"
-    stderr_path = log_dir / f"{job_name}_%j.err"
+    cmd: list[str] = [str(gpu_ctx.script), "--job-name", job_name]
 
-    cmd = ["sbatch", "--parsable"]
-    if partition:
-        cmd.append(f"--partition={partition}")
-    if gres:
-        cmd.append(f"--gres={gres}")
-    if cpus:
-        cmd.append(f"--cpus-per-task={cpus}")
-    if mem:
-        cmd.append(f"--mem={mem}")
-    if time_limit:
-        cmd.append(f"--time={time_limit}")
-    cmd.extend(
-        [
-            f"--job-name={job_name}",
-            f"--output={stdout_path}",
-            f"--error={stderr_path}",
-            f"--export={export_arg}",
-            str(worker_script),
-        ]
-    )
-    result = run_command(cmd)
-    out = (result.stdout or "").strip()
-    err = (result.stderr or "").strip()
+    if gpu_ctx.gpu_count:
+        cmd.extend(["--gpu-count", str(gpu_ctx.gpu_count)])
+    if gpu_ctx.cpus:
+        cmd.extend(["--cpus", str(gpu_ctx.cpus)])
+    if gpu_ctx.memory:
+        cmd.extend(["--mem", gpu_ctx.memory])
+    if gpu_ctx.time_limit:
+        cmd.extend(["--time", gpu_ctx.time_limit])
+    if gpu_ctx.work_dir:
+        cmd.extend(["--workdir", str(gpu_ctx.work_dir)])
+    if gpu_ctx.compiler_module:
+        cmd.extend(["--compiler-module", gpu_ctx.compiler_module])
+    if gpu_ctx.cuda_module:
+        cmd.extend(["--cuda-module", gpu_ctx.cuda_module])
+    for module_name in gpu_ctx.extra_modules:
+        if module_name:
+            cmd.extend(["--module", module_name])
+    if gpu_ctx.poll_interval is not None:
+        cmd.extend(["--poll-interval", str(gpu_ctx.poll_interval)])
+    if gpu_ctx.poll_timeout is not None:
+        cmd.extend(["--poll-timeout", str(gpu_ctx.poll_timeout)])
 
-    if result.returncode == 0 and out:
-        job_id = out.splitlines()[0]
-        print(f"Submitted {combo.label} as JobID {job_id}", flush=True)
-        return job_id, False, ""
+    cmd.extend([
+        "--assay",
+        combo.assay,
+        "--model",
+        combo.model,
+        "--mf",
+        combo.fingerprint,
+        "--label",
+        job_name,
+        "--seed",
+        "multi",
+        "--",
+    ])
+
+    env_pairs = [f"{key}={value}" for key, value in sorted((k, str(v)) for k, v in env.items())]
+    cmd.append("env")
+    cmd.extend(env_pairs)
+    cmd.append(str(worker_script))
+
+    result = subprocess.run(cmd, check=False, capture_output=True, text=True)
+    out = (result.stdout or "")
+    err = (result.stderr or "")
+
+    if out:
+        print(out, end="", flush=True)
+    if err:
+        print(err, file=sys.stderr, end="", flush=True)
+
+    if result.returncode == 0:
+        match = re.search(r"Final allocated job ID: (\S+)", out)
+        if match:
+            job_id = match.group(1)
+            print(f"Submitted {combo.label} as JobID {job_id}", flush=True)
+            return job_id, False, ""
+        failure_reason = "submit succeeded but job id missing"
+        print(f"[error] {failure_reason} for {combo.label}", file=sys.stderr, flush=True)
+        return None, False, failure_reason
 
     if is_submit_limit_error(out, err):
-        # submit-limit은 스로틀 신호로 외부에서 처리
         print(f"[throttle] submit-limit hit for {combo.label}; deferring...", file=sys.stderr, flush=True)
         return None, True, (err or out or "submit-limit")
 
-    failure_reason = err or out or "unknown error"
+    failure_reason = (err or out or "unknown error").strip()
     print(f"[error] Failed to submit {combo.label}: {failure_reason}", file=sys.stderr, flush=True)
     return None, False, failure_reason
 
@@ -357,6 +463,7 @@ def build_env(
     #conda_cfg = env_cfg.get("conda", {})
     #env["CONDA_SETUP"] = conda_cfg.get("setup", "")
     #env["CONDA_ENV"] = conda_cfg.get("env", "")
+    env["USE_GPU"] = "1" if normalise_bool(env_cfg.get("use_gpu", True), True) else "0"
     if random_state is not None:
         env["RANDOM_STATE"] = str(random_state)
     return env
@@ -433,6 +540,44 @@ def main(argv: Sequence[str] | None = None) -> int:
     slurm_log_dir.mkdir(parents=True, exist_ok=True)
 
     env_cfg = config.get("environment", {})
+    module_cfg = env_cfg.get("module", {})
+    compiler_module, cuda_module, extra_modules = normalise_module_config(module_cfg)
+
+    if args.max_queue == parser.get_default("max_queue") and slurm_cfg.get("max_jobs"):
+        args.max_queue = int(slurm_cfg["max_jobs"])
+
+    throttle_cfg = slurm_cfg.get("throttle", {})
+    if args.max_queue == parser.get_default("max_queue") and throttle_cfg.get("max_queue"):
+        args.max_queue = int(throttle_cfg["max_queue"])
+    if args.poll_interval == parser.get_default("poll_interval") and throttle_cfg.get("poll_interval_sec"):
+        args.poll_interval = int(throttle_cfg["poll_interval_sec"])
+
+    gpu_submit_cfg = slurm_cfg.get("gpu_submit", {})
+    poll_interval_raw = gpu_submit_cfg.get("poll_interval")
+    if poll_interval_raw is None:
+        poll_interval_raw = gpu_submit_cfg.get("poll_interval_sec")
+    poll_timeout_raw = gpu_submit_cfg.get("poll_timeout")
+    if poll_timeout_raw is None:
+        poll_timeout_raw = gpu_submit_cfg.get("poll_timeout_sec")
+
+    gpu_poll_interval = coerce_optional_int(poll_interval_raw, "gpu_submit.poll_interval")
+    gpu_poll_timeout = coerce_optional_int(poll_timeout_raw, "gpu_submit.poll_timeout")
+
+    gpu_submit_script = worker_script.with_name("gpu_submit.sh")
+    gpu_count = parse_gpu_count(slurm_cfg.get("gres")) or 1
+    gpu_ctx = GpuSubmitContext(
+        script=gpu_submit_script,
+        work_dir=base_dir,
+        gpu_count=gpu_count,
+        cpus=slurm_cfg.get("cpus_per_task"),
+        memory=slurm_cfg.get("mem"),
+        time_limit=slurm_cfg.get("time"),
+        compiler_module=compiler_module,
+        cuda_module=cuda_module,
+        extra_modules=extra_modules,
+        poll_interval=gpu_poll_interval,
+        poll_timeout=gpu_poll_timeout,
+    )
 
     if args.dry_run or training_cfg.get("dry_run", False):
         print("[dry-run] user-wide throttled submission")
@@ -450,7 +595,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         # 2) 제출 시도; submit-limit이면 대기 후 재시도
         while True:
             env = build_env(combo, base_dir, model_dir, run_subdir, logs_dir, results_dir, worker_seed_file, env_cfg, random_state)
-            job_id, submit_limited, reason = submit_job_once(worker_script, combo, env, slurm_cfg, slurm_log_dir)
+            job_id, submit_limited, reason = submit_job_once(worker_script, combo, env, gpu_ctx)
             if submit_limited:
                 # 사용자의 타 잡/어카운트 제한 포함. 일정 시간 대기 후 다시 squeue 기반 스로틀부터 반복.
                 time.sleep(args.poll_interval)

--- a/slurm/train_combo_worker.sh
+++ b/slurm/train_combo_worker.sh
@@ -224,6 +224,14 @@ while IFS='|' read -r seed_dir seed_name; do
          --train_csv "$train_csv" --val_csv "$val_csv" --test_csv "$test_csv"
          --train_fp_dir "$train_fp_dir" --val_fp_dir "$val_fp_dir" --test_fp_dir "$test_fp_dir"
          --assay_name "$ASSAY_NAME" --model_save_path "$save_dir")
+    case "${USE_GPU:-auto}" in
+        1|[Tt][Rr][Uu][Ee]|[Yy][Ee][Ss]|[Oo][Nn])
+            cmd+=(--use-gpu)
+            ;;
+        0|[Ff][Aa][Ll][Ss][Ee]|[Nn][Oo]|[Oo][Ff][Ff])
+            cmd+=(--no-gpu)
+            ;;
+    esac
     if [ -n "$RANDOM_STATE" ]; then
         cmd+=(--random_state "$RANDOM_STATE")
     fi


### PR DESCRIPTION
## Summary
- update the v3 training submitter to drive `gpu_submit.sh`, derive module/GPU options from config, and normalise worker env exports
- plumb a GPU toggle into the combo worker so the per-model runners receive `--use-gpu` when dispatched via the GPU helper

## Testing
- python -m compileall slurm/submit_v3_training.py
- bash -n slurm/train_combo_worker.sh
- bash -n slurm/gpu_submit.sh
- python -m compileall ToxCast_model/run_v3

------
https://chatgpt.com/codex/tasks/task_e_68da2fe6e5a88320a72698791187fa5c