### PR TITLE
Ensure stderr logs are captured alongside training logs

### DIFF
--- a/slurm/run_training.sh
+++ b/slurm/run_training.sh
@@ -152,7 +152,9 @@ elif [ "$version" = "3" ]; then
         log_dir="$seed_logs_dir/$assay"
         save_dir="$seed_results_dir/${assay}_${model}_${fp}"
         log_file="$log_dir/${assay}_${model}_${fp}.log"
+        err_file="$log_dir/${assay}_${model}_${fp}.err"
         mkdir -p "$save_dir" "$log_dir"
+        : > "$err_file"
 
         # 외부 함수: resolve_seed_paths (프로젝트에 이미 존재한다고 가정)
         resolve_seed_paths "$seed_dir"
@@ -185,8 +187,9 @@ elif [ "$version" = "3" ]; then
             --test_fp_dir "$test_fp_dir" \
             --assay_name "$assay" \
             --model_save_path "$save_dir" \
-            2>&1 | tee -a "$log_file" >&2
-        exit_code=${PIPESTATUS[0]}
+            > >(tee -a "$log_file") \
+            2> >(tee -a "$err_file" | tee -a "$log_file" >&2)
+        exit_code=$?
         set -e
 
         end_time=$(date +%s)

--- a/slurm/train_combo_worker.sh
+++ b/slurm/train_combo_worker.sh
@@ -208,7 +208,9 @@ while IFS='|' read -r seed_dir seed_name; do
     seed_logs_dir="$LOGS_DIR/$seed_name"
     log_dir="$seed_logs_dir/$ASSAY_NAME"
     log_file="$log_dir/${ASSAY_NAME}_${MODEL_NAME}_${FINGERPRINT_NAME}.log"
+    err_file="$log_dir/${ASSAY_NAME}_${MODEL_NAME}_${FINGERPRINT_NAME}.err"
     mkdir -p "$seed_results_dir" "$log_dir"
+    : > "$err_file"
 
     resolve_seed_paths "$seed_dir"
     if [ ! -f "$train_csv" ]; then
@@ -242,8 +244,10 @@ while IFS='|' read -r seed_dir seed_name; do
     fi
 
     set +e
-    "${cmd[@]}" 2>&1 | tee -a "$log_file"
-    exit_code=${PIPESTATUS[0]}
+    "${cmd[@]}" \
+        > >(tee -a "$log_file") \
+        2> >(tee -a "$err_file" | tee -a "$log_file" >&2)
+    exit_code=$?
     set -e
 
     end_ts="$(date '+%F %T')"


### PR DESCRIPTION
## Summary
- ensure training worker scripts create `.err` files alongside performance `.log` files
- tee stderr output (including tqdm progress) into the new `.err` files while keeping the `.log` content intact

## Testing
- not run (infrastructure change only)


------
https://chatgpt.com/codex/tasks/task_e_68da9601b0fc832087acc3df5a7402d4